### PR TITLE
feat(icon): add reusable Icon component with Tailwind

### DIFF
--- a/libs/ngx-tailwind-flex-ui/.storybook/main.ts
+++ b/libs/ngx-tailwind-flex-ui/.storybook/main.ts
@@ -1,6 +1,4 @@
 import type { StorybookConfig } from '@storybook/angular';
-import { Configuration } from 'webpack';
-import * as path from 'path';
 
 const config: StorybookConfig = {
   stories: ['../**/*.@(mdx|stories.@(js|jsx|ts|tsx))'],

--- a/libs/ngx-tailwind-flex-ui/.storybook/preview.ts
+++ b/libs/ngx-tailwind-flex-ui/.storybook/preview.ts
@@ -1,5 +1,10 @@
 import 'zone.js';
 
+const link = document.createElement('link');
+link.rel = 'stylesheet';
+link.href = 'https://fonts.googleapis.com/icon?family=Material+Icons';
+document.head.appendChild(link);
+
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {

--- a/libs/ngx-tailwind-flex-ui/documentation.json
+++ b/libs/ngx-tailwind-flex-ui/documentation.json
@@ -91,6 +91,103 @@
                 }
             },
             "templateData": "<button [disabled]=\"disabled\">\n  <ng-content></ng-content>\n</button>\n"
+        },
+        {
+            "name": "IconComponent",
+            "id": "component-IconComponent-5aa773a6e880c2e7321715a97108ab13b79bb19e782154c23dd13ec81d958ee42c3cc1a64ae98a42a5ed510500e262d6416046a36c79ddd1e54057a95c34f581",
+            "file": "libs/ngx-tailwind-flex-ui/src/lib/icon/icon.component.ts",
+            "encapsulation": [],
+            "entryComponents": [],
+            "inputs": [],
+            "outputs": [],
+            "providers": [],
+            "selector": "lib-icon",
+            "styleUrls": [
+                "./icon.component.css"
+            ],
+            "styles": [],
+            "templateUrl": [
+                "./icon.component.html"
+            ],
+            "viewProviders": [],
+            "hostDirectives": [],
+            "inputsClass": [
+                {
+                    "name": "color",
+                    "defaultValue": "'text-gray-500'",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 14,
+                    "type": "string",
+                    "decorators": []
+                },
+                {
+                    "name": "name",
+                    "defaultValue": "'home'",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 12,
+                    "type": "string",
+                    "decorators": []
+                },
+                {
+                    "name": "size",
+                    "defaultValue": "'md'",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 13,
+                    "type": "\"sm\" | \"md\" | \"lg\" | \"xl\"",
+                    "decorators": []
+                }
+            ],
+            "outputsClass": [],
+            "propertiesClass": [],
+            "methodsClass": [],
+            "deprecated": false,
+            "deprecationMessage": "",
+            "hostBindings": [],
+            "hostListeners": [],
+            "standalone": true,
+            "imports": [
+                {
+                    "name": "CommonModule",
+                    "type": "module"
+                }
+            ],
+            "description": "",
+            "rawdescription": "\n",
+            "type": "component",
+            "sourceCode": "import { Component, Input } from '@angular/core';\nimport { CommonModule } from '@angular/common'; \n\n@Component({\n  selector: 'lib-icon',\n  standalone: true,\n  imports: [CommonModule],\n  templateUrl: './icon.component.html',\n  styleUrls: ['./icon.component.css'],\n})\nexport class IconComponent {\n  @Input() name = 'home';\n  @Input() size: 'sm' | 'md' | 'lg' | 'xl' = 'md';\n  @Input() color = 'text-gray-500';\n\n  get sizeClass(): string {\n    const sizeMap = {\n      sm: 'text-sm',\n      md: 'text-base',\n      lg: 'text-2xl',\n      xl: 'text-4xl',\n    };\n    return sizeMap[this.size] || sizeMap.md;\n  }\n\n  get colorClass(): string {\n    return this.color;\n  }\n}\n",
+            "assetsDirs": [],
+            "styleUrlsData": [
+                {
+                    "data": ".material-icons {\n    display: inline-flex;\n    align-items: center;\n    justify-content: center;\n    vertical-align: middle;\n}",
+                    "styleUrl": "./icon.component.css"
+                }
+            ],
+            "stylesData": "",
+            "extends": [],
+            "accessors": {
+                "sizeClass": {
+                    "name": "sizeClass",
+                    "getSignature": {
+                        "name": "sizeClass",
+                        "type": "string",
+                        "returnType": "string",
+                        "line": 16
+                    }
+                },
+                "colorClass": {
+                    "name": "colorClass",
+                    "getSignature": {
+                        "name": "colorClass",
+                        "type": "string",
+                        "returnType": "string",
+                        "line": 26
+                    }
+                }
+            },
+            "templateData": "<span class=\"material-icons\" [ngClass]=\"[sizeClass, colorClass]\">\n    {{ name }}\n</span>\n  "
         }
     ],
     "modules": [],
@@ -127,6 +224,16 @@
                 "defaultValue": "{\n  args: {\n    variant: 'primary',\n    class: 'text-lg px-6 py-3 bg-green-500 hover:bg-green-600',\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-button [variant]=\"variant\" [class]=\"class\">Custom Styled Button</lib-button>`,\n  }),\n}"
             },
             {
+                "name": "Default",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "libs/ngx-tailwind-flex-ui/src/lib/icon/icon.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "Story",
+                "defaultValue": "{\n  args: {\n    name: 'home',\n    size: 'md',\n    color: 'text-gray-500',\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-icon [name]=\"name\" [size]=\"size\" [color]=\"color\"></lib-icon>`,\n  }),\n}"
+            },
+            {
                 "name": "Disabled",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
@@ -135,6 +242,26 @@
                 "deprecationMessage": "",
                 "type": "Story",
                 "defaultValue": "{\n  args: {\n    variant: 'primary',\n    disabled: true,\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-button [variant]=\"variant\" [disabled]=\"disabled\">Disabled Button</lib-button>`,\n  }),\n}"
+            },
+            {
+                "name": "LargeRedIcon",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "libs/ngx-tailwind-flex-ui/src/lib/icon/icon.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "Story",
+                "defaultValue": "{\n  args: {\n    name: 'favorite',\n    size: 'xl',\n    color: 'text-red-500',\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-icon [name]=\"name\" [size]=\"size\" [color]=\"color\"></lib-icon>`,\n  }),\n}"
+            },
+            {
+                "name": "link",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "libs/ngx-tailwind-flex-ui/.storybook/preview.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "document.createElement('link')"
             },
             {
                 "name": "meta",
@@ -147,6 +274,16 @@
                 "defaultValue": "{\n  title: 'Components/Button',\n  component: ButtonComponent,\n  tags: ['autodocs'],\n  argTypes: {\n    variant: {\n      control: 'select',\n      options: ['primary', 'accent', 'outline', 'text'],\n      description: 'Button style variant',\n    },\n    disabled: {\n      control: 'boolean',\n      description: 'Disables the button',\n    },\n    class: {\n      control: 'text',\n      description: 'Additional Tailwind CSS classes for customization',\n    },\n  },\n}"
             },
             {
+                "name": "meta",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "libs/ngx-tailwind-flex-ui/src/lib/icon/icon.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "Meta<IconComponent>",
+                "defaultValue": "{\n  title: 'Components/Icon',\n  component: IconComponent,\n  tags: ['autodocs'],\n  argTypes: {\n    name: { control: 'text', description: 'Icon name from Material Icons' },\n    size: { \n      control: 'radio', \n      options: ['sm', 'md', 'lg', 'xl'], \n      description: 'Size of the icon' \n    },\n    color: { control: 'text', description: 'Tailwind color classes' },\n  },\n}"
+            },
+            {
                 "name": "Outline",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
@@ -157,6 +294,16 @@
                 "defaultValue": "{\n  args: {\n    variant: 'outline',\n    disabled: false,\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-button [variant]=\"variant\" [disabled]=\"disabled\">Outline Button</lib-button>`,\n  }),\n}"
             },
             {
+                "name": "parameters",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "libs/ngx-tailwind-flex-ui/.storybook/preview.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "object",
+                "defaultValue": "{\n  actions: { argTypesRegex: '^on[A-Z].*' },\n  controls: {\n    matchers: {\n      color: /(background|color)$/i,\n      date: /Date$/,\n    },\n  },\n}"
+            },
+            {
                 "name": "Primary",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
@@ -165,6 +312,16 @@
                 "deprecationMessage": "",
                 "type": "Story",
                 "defaultValue": "{\n  args: {\n    variant: 'primary',\n    disabled: false,\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-button [variant]=\"variant\" [disabled]=\"disabled\">Primary Button</lib-button>`,\n  }),\n}"
+            },
+            {
+                "name": "SmallBlueIcon",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "libs/ngx-tailwind-flex-ui/src/lib/icon/icon.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "Story",
+                "defaultValue": "{\n  args: {\n    name: 'star',\n    size: 'sm',\n    color: 'text-blue-500',\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-icon [name]=\"name\" [size]=\"size\" [color]=\"color\"></lib-icon>`,\n  }),\n}"
             },
             {
                 "name": "Text",
@@ -185,6 +342,17 @@
                 "subtype": "typealias",
                 "rawtype": "StoryObj<ButtonComponent>",
                 "file": "libs/ngx-tailwind-flex-ui/src/lib/button/button.component.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "description": "",
+                "kind": 183
+            },
+            {
+                "name": "Story",
+                "ctype": "miscellaneous",
+                "subtype": "typealias",
+                "rawtype": "StoryObj<IconComponent>",
+                "file": "libs/ngx-tailwind-flex-ui/src/lib/icon/icon.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "description": "",
@@ -276,6 +444,70 @@
                     "type": "StorybookConfig",
                     "defaultValue": "{\n  stories: ['../**/*.@(mdx|stories.@(js|jsx|ts|tsx))'],\n  addons: ['@storybook/addon-essentials', '@storybook/addon-interactions'],\n  framework: {\n    name: '@storybook/angular',\n    options: {},\n  },\n  docs: {\n    autodocs: true,\n    defaultName: 'Docs',\n  },\n}"
                 }
+            ],
+            "libs/ngx-tailwind-flex-ui/src/lib/icon/icon.stories.ts": [
+                {
+                    "name": "Default",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "libs/ngx-tailwind-flex-ui/src/lib/icon/icon.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "Story",
+                    "defaultValue": "{\n  args: {\n    name: 'home',\n    size: 'md',\n    color: 'text-gray-500',\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-icon [name]=\"name\" [size]=\"size\" [color]=\"color\"></lib-icon>`,\n  }),\n}"
+                },
+                {
+                    "name": "LargeRedIcon",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "libs/ngx-tailwind-flex-ui/src/lib/icon/icon.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "Story",
+                    "defaultValue": "{\n  args: {\n    name: 'favorite',\n    size: 'xl',\n    color: 'text-red-500',\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-icon [name]=\"name\" [size]=\"size\" [color]=\"color\"></lib-icon>`,\n  }),\n}"
+                },
+                {
+                    "name": "meta",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "libs/ngx-tailwind-flex-ui/src/lib/icon/icon.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "Meta<IconComponent>",
+                    "defaultValue": "{\n  title: 'Components/Icon',\n  component: IconComponent,\n  tags: ['autodocs'],\n  argTypes: {\n    name: { control: 'text', description: 'Icon name from Material Icons' },\n    size: { \n      control: 'radio', \n      options: ['sm', 'md', 'lg', 'xl'], \n      description: 'Size of the icon' \n    },\n    color: { control: 'text', description: 'Tailwind color classes' },\n  },\n}"
+                },
+                {
+                    "name": "SmallBlueIcon",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "libs/ngx-tailwind-flex-ui/src/lib/icon/icon.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "Story",
+                    "defaultValue": "{\n  args: {\n    name: 'star',\n    size: 'sm',\n    color: 'text-blue-500',\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-icon [name]=\"name\" [size]=\"size\" [color]=\"color\"></lib-icon>`,\n  }),\n}"
+                }
+            ],
+            "libs/ngx-tailwind-flex-ui/.storybook/preview.ts": [
+                {
+                    "name": "link",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "libs/ngx-tailwind-flex-ui/.storybook/preview.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "document.createElement('link')"
+                },
+                {
+                    "name": "parameters",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "libs/ngx-tailwind-flex-ui/.storybook/preview.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "object",
+                    "defaultValue": "{\n  actions: { argTypesRegex: '^on[A-Z].*' },\n  controls: {\n    matchers: {\n      color: /(background|color)$/i,\n      date: /Date$/,\n    },\n  },\n}"
+                }
             ]
         },
         "groupedFunctions": {},
@@ -288,6 +520,19 @@
                     "subtype": "typealias",
                     "rawtype": "StoryObj<ButtonComponent>",
                     "file": "libs/ngx-tailwind-flex-ui/src/lib/button/button.component.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "description": "",
+                    "kind": 183
+                }
+            ],
+            "libs/ngx-tailwind-flex-ui/src/lib/icon/icon.stories.ts": [
+                {
+                    "name": "Story",
+                    "ctype": "miscellaneous",
+                    "subtype": "typealias",
+                    "rawtype": "StoryObj<IconComponent>",
+                    "file": "libs/ngx-tailwind-flex-ui/src/lib/icon/icon.stories.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "description": "",
@@ -307,6 +552,26 @@
                 "linktype": "miscellaneous",
                 "linksubtype": "variable",
                 "name": "config",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "libs/ngx-tailwind-flex-ui/.storybook/preview.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "link",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "libs/ngx-tailwind-flex-ui/.storybook/preview.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "parameters",
                 "coveragePercent": 0,
                 "coverageCount": "0/1",
                 "status": "low"
@@ -398,6 +663,65 @@
                 "name": "ButtonComponent",
                 "coveragePercent": 0,
                 "coverageCount": "0/5",
+                "status": "low"
+            },
+            {
+                "filePath": "libs/ngx-tailwind-flex-ui/src/lib/icon/icon.component.ts",
+                "type": "component",
+                "linktype": "component",
+                "name": "IconComponent",
+                "coveragePercent": 0,
+                "coverageCount": "0/4",
+                "status": "low"
+            },
+            {
+                "filePath": "libs/ngx-tailwind-flex-ui/src/lib/icon/icon.stories.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "Default",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "libs/ngx-tailwind-flex-ui/src/lib/icon/icon.stories.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "LargeRedIcon",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "libs/ngx-tailwind-flex-ui/src/lib/icon/icon.stories.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "meta",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "libs/ngx-tailwind-flex-ui/src/lib/icon/icon.stories.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "SmallBlueIcon",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "libs/ngx-tailwind-flex-ui/src/lib/icon/icon.stories.ts",
+                "type": "type alias",
+                "linktype": "miscellaneous",
+                "linksubtype": "typealias",
+                "name": "Story",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
                 "status": "low"
             }
         ]

--- a/libs/ngx-tailwind-flex-ui/package.json
+++ b/libs/ngx-tailwind-flex-ui/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "peerDependencies": {
     "@angular/core": "^19.1.0",
+    "@angular/common": "^19.1.0",
     "@nx/angular": "20.4.6"
   },
   "sideEffects": false

--- a/libs/ngx-tailwind-flex-ui/src/lib/icon/icon.component.css
+++ b/libs/ngx-tailwind-flex-ui/src/lib/icon/icon.component.css
@@ -1,0 +1,6 @@
+.material-icons {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    vertical-align: middle;
+}

--- a/libs/ngx-tailwind-flex-ui/src/lib/icon/icon.component.html
+++ b/libs/ngx-tailwind-flex-ui/src/lib/icon/icon.component.html
@@ -1,0 +1,4 @@
+<span class="material-icons" [ngClass]="[sizeClass, colorClass]">
+    {{ name }}
+</span>
+  

--- a/libs/ngx-tailwind-flex-ui/src/lib/icon/icon.component.spec.ts
+++ b/libs/ngx-tailwind-flex-ui/src/lib/icon/icon.component.spec.ts
@@ -1,0 +1,47 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { IconComponent } from './icon.component';
+import { CommonModule } from '@angular/common'; 
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+
+describe('IconComponent', () => {
+  let component: IconComponent;
+  let fixture: ComponentFixture<IconComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CommonModule, IconComponent], 
+      schemas: [NO_ERRORS_SCHEMA], 
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(IconComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display the correct icon', () => {
+    component.name = 'search';
+    fixture.detectChanges();
+    const span = fixture.nativeElement.querySelector('span');
+    expect(span.textContent.trim()).toBe('search');
+  });
+
+  it('should apply correct size class', () => {
+    component.size = 'lg';
+    fixture.detectChanges();
+    const span = fixture.nativeElement.querySelector('span');
+    expect(span.classList).toContain('text-2xl');
+  });
+
+  it('should apply custom color', () => {
+    component.color = 'text-blue-500';
+    fixture.detectChanges();
+    const span = fixture.nativeElement.querySelector('span');
+    expect(span.classList).toContain('text-blue-500');
+  });
+});

--- a/libs/ngx-tailwind-flex-ui/src/lib/icon/icon.component.ts
+++ b/libs/ngx-tailwind-flex-ui/src/lib/icon/icon.component.ts
@@ -1,0 +1,29 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common'; 
+
+@Component({
+  selector: 'lib-icon',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './icon.component.html',
+  styleUrls: ['./icon.component.css'],
+})
+export class IconComponent {
+  @Input() name = 'home';
+  @Input() size: 'sm' | 'md' | 'lg' | 'xl' = 'md';
+  @Input() color = 'text-gray-500';
+
+  get sizeClass(): string {
+    const sizeMap = {
+      sm: 'text-sm',
+      md: 'text-base',
+      lg: 'text-2xl',
+      xl: 'text-4xl',
+    };
+    return sizeMap[this.size] || sizeMap.md;
+  }
+
+  get colorClass(): string {
+    return this.color;
+  }
+}

--- a/libs/ngx-tailwind-flex-ui/src/lib/icon/icon.stories.ts
+++ b/libs/ngx-tailwind-flex-ui/src/lib/icon/icon.stories.ts
@@ -1,0 +1,57 @@
+import { Meta, StoryObj } from '@storybook/angular';
+import { IconComponent } from './icon.component';
+
+const meta: Meta<IconComponent> = {
+  title: 'Components/Icon',
+  component: IconComponent,
+  tags: ['autodocs'],
+  argTypes: {
+    name: { control: 'text', description: 'Icon name from Material Icons' },
+    size: { 
+      control: 'radio', 
+      options: ['sm', 'md', 'lg', 'xl'], 
+      description: 'Size of the icon' 
+    },
+    color: { control: 'text', description: 'Tailwind color classes' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<IconComponent>;
+
+export const Default: Story = {
+  args: {
+    name: 'home',
+    size: 'md',
+    color: 'text-gray-500',
+  },
+  render: (args) => ({
+    props: args,
+    template: `<lib-icon [name]="name" [size]="size" [color]="color"></lib-icon>`,
+  }),
+};
+
+export const LargeRedIcon: Story = {
+  args: {
+    name: 'favorite',
+    size: 'xl',
+    color: 'text-red-500',
+  },
+  render: (args) => ({
+    props: args,
+    template: `<lib-icon [name]="name" [size]="size" [color]="color"></lib-icon>`,
+  }),
+};
+
+export const SmallBlueIcon: Story = {
+  args: {
+    name: 'star',
+    size: 'sm',
+    color: 'text-blue-500',
+  },
+  render: (args) => ({
+    props: args,
+    template: `<lib-icon [name]="name" [size]="size" [color]="color"></lib-icon>`,
+  }),
+};

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@module-federation/enhanced": "^0.9.1",
     "@module-federation/manifest": "^0.9.1",
     "@module-federation/rspack": "^0.9.1",
-    "@nx/angular": "20.4.6",
+    "@nx/angular": "^20.4.6",
     "@nx/devkit": "20.4.6",
     "@nx/eslint": "20.4.6",
     "@nx/eslint-plugin": "20.4.6",


### PR DESCRIPTION

<img width="1503" alt="Screenshot 2025-03-03 at 12 28 39" src="https://github.com/user-attachments/assets/1158178f-a19b-40da-8d78-384899c5936f" />
Introduces a standalone Angular Icon component with full Tailwind CSS support, allowing dynamic customization of size, color, and icon name. The component utilizes Material Icons and integrates seamlessly with Storybook for interactive UI testing.

**Features Added:**
Standalone IconComponent with Material Icons support.
Dynamic inputs:
name: Material Icon name.
size: Supports sm | md | lg | xl.
color: Allows Tailwind color classes.
Storybook Integration:
Uses StoryObj for structured and interactive component documentation.
Includes multiple stories (Default, LargeRedIcon, SmallBlueIcon).
Unit Tests:
Ensures the component renders correctly.
Validates dynamic size and color application.
Fixes & Improvements:
Fixed Storybook Issue: Ensured Material Icons load correctly by injecting fonts dynamically in preview.ts.
Resolved Lint Errors: Updated peerDependencies to include @angular/common for ngClass support.