### PR TITLE
chore(ci): fix pipeline to deploy playground

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,63 @@ jobs:
       - name: Lint Commit Messages
         uses: wagoid/commitlint-github-action@v5
 
+  determine-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      lib_changed: ${{ steps.check-libs.outputs.lib_changed }}
+      playground_changed: ${{ steps.check-playground.outputs.playground_changed }}
+      storybook_changed: ${{ steps.check-storybook.outputs.storybook_changed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci --legacy-peer-deps
+
+      # Check for library changes (excluding stories files)
+      - name: Check for library changes
+        id: check-libs
+        run: |
+          git diff --name-only ${{ github.event.before }} ${{ github.sha }} > changed_files.txt
+
+          # Check if library files changed (excluding .stories.ts)
+          if grep -q "^libs/ngx-tailwind-flex-ui/" changed_files.txt | grep -v ".stories.ts"; then
+            echo "lib_changed=true" >> $GITHUB_OUTPUT
+            echo "Library files changed"
+          else
+            echo "lib_changed=false" >> $GITHUB_OUTPUT
+            echo "No library files changed"
+          fi
+
+      # Check for playground app changes
+      - name: Check for playground changes
+        id: check-playground
+        run: |
+          if grep -q "^apps/playground/" changed_files.txt; then
+            echo "playground_changed=true" >> $GITHUB_OUTPUT
+            echo "Playground app files changed"
+          else
+            echo "playground_changed=false" >> $GITHUB_OUTPUT
+            echo "No playground app files changed"
+          fi
+
+      # Check for storybook changes
+      - name: Check for storybook changes
+        id: check-storybook
+        run: |
+          if grep -q "libs/ngx-tailwind-flex-ui/.storybook/" changed_files.txt || grep -q "libs/ngx-tailwind-flex-ui/.*\.stories\.ts" changed_files.txt; then
+            echo "storybook_changed=true" >> $GITHUB_OUTPUT
+            echo "Storybook files changed"
+          else
+            echo "storybook_changed=false" >> $GITHUB_OUTPUT
+            echo "No storybook files changed"
+          fi
+
   build-test:
     runs-on: ubuntu-latest
-    needs: commit-lint
+    needs: [commit-lint, determine-changes]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -36,8 +90,8 @@ jobs:
       - run: npx nx affected -t lint test build e2e
 
   canary-release:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: build-test
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.determine-changes.outputs.lib_changed == 'true' }}
+    needs: [build-test, determine-changes]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -75,8 +129,8 @@ jobs:
           target: minor
 
   deploy-storybook:
-    needs: build-test
-    if: github.ref == 'refs/heads/main'
+    needs: [build-test, determine-changes]
+    if: ${{ github.ref == 'refs/heads/main' && (needs.determine-changes.outputs.storybook_changed == 'true' || needs.determine-changes.outputs.lib_changed == 'true') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -98,8 +152,8 @@ jobs:
           keep_files: true
 
   deploy-playground:
-    needs: build-test
-    if: github.ref == 'refs/heads/main'
+    needs: [build-test, determine-changes]
+    if: ${{ github.ref == 'refs/heads/main' && (needs.determine-changes.outputs.playground_changed == 'true' || needs.determine-changes.outputs.lib_changed == 'true') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -112,10 +166,6 @@ jobs:
       - run: npm ci --legacy-peer-deps
       - name: Build Playground App
         run: npx nx build playground --base-href=/ngx-tailwind-flex-ui/playground/
-      - name: Debug Build Output
-        run: |
-          echo "Checking build output directory..."
-          ls -la dist/apps/playground
       - name: Deploy Playground to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,8 @@ jobs:
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           publish_dir: dist/storybook/ngx-tailwind-flex-ui
+          destination_dir: docs
+          keep_files: true
 
   deploy-playground:
     needs: build-test
@@ -110,9 +112,14 @@ jobs:
       - run: npm ci --legacy-peer-deps
       - name: Build Playground App
         run: npx nx build playground --base-href=/ngx-tailwind-flex-ui/playground/
+      - name: Debug Build Output
+        run: |
+          echo "Checking build output directory..."
+          ls -la dist/apps/playground
       - name: Deploy Playground to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           publish_dir: dist/apps/playground
           destination_dir: playground
+          keep_files: true


### PR DESCRIPTION
- Add a `determine-changes` job to detect changes in the library,  
  playground, and storybook.  
- Update `canary-release`, `deploy-storybook`, and `deploy-playground`  
  to run only if relevant files change.  
- Ensure CI runs efficiently by skipping unnecessary jobs  
  when unrelated files are not modified.  