### PR TITLE
feat(ui): add Paginator component

### DIFF
--- a/.hintrc
+++ b/.hintrc
@@ -1,0 +1,8 @@
+{
+  "extends": [
+    "development"
+  ],
+  "hints": {
+    "axe/forms": "off"
+  }
+}

--- a/libs/ngx-tailwind-flex-ui/src/lib/paginator/paginator.component.html
+++ b/libs/ngx-tailwind-flex-ui/src/lib/paginator/paginator.component.html
@@ -1,0 +1,31 @@
+<!-- Page Size Selector -->
+<div class="flex items-center space-x-2">
+  <label for="pageSizeSelect" class="text-gray-600 text-sm">Items per page:</label>
+  <select 
+    id="pageSizeSelect"
+    [value]="pageSize"
+    (change)="changePageSize($event)"
+    class="border border-gray-300 rounded-md px-2 py-2 bg-white text-gray-700">
+    <option *ngFor="let size of pageSizeOptions" [value]="size">{{ size }}</option>
+  </select>
+</div>
+
+<!-- Page Information -->
+<span class="text-gray-500 text-sm">
+  {{ startItem }} – {{ endItem }} of {{ length }}
+</span>
+
+<!-- Navigation Controls -->
+<button 
+  [disabled]="isFirstPage"
+  (click)="changePage(pageIndex - 1)"
+  class="p-2 text-gray-500 hover:text-black disabled:opacity-50">
+  ❮
+</button>
+
+<button 
+  [disabled]="isLastPage"
+  (click)="changePage(pageIndex + 1)"
+  class="p-2 text-gray-500 hover:text-black disabled:opacity-50">
+  ❯
+</button>

--- a/libs/ngx-tailwind-flex-ui/src/lib/paginator/paginator.component.spec.ts
+++ b/libs/ngx-tailwind-flex-ui/src/lib/paginator/paginator.component.spec.ts
@@ -1,0 +1,103 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PaginatorComponent } from './paginator.component';
+import { CommonModule } from '@angular/common';
+import { By } from '@angular/platform-browser';
+
+describe('PaginatorComponent', () => {
+  let component: PaginatorComponent;
+  let fixture: ComponentFixture<PaginatorComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CommonModule, PaginatorComponent], // Import component directly
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PaginatorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create the paginator component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should have default pageSize of 10', () => {
+    expect(component.pageSize).toBe(10);
+  });
+
+  it('should display correct initial page range', () => {
+    const pageInfo = fixture.debugElement.query(By.css('span.text-gray-500')).nativeElement;
+    expect(pageInfo.textContent.trim()).toBe('1 – 10 of 100');
+  });
+
+  it('should disable previous button on first page', () => {
+    const prevButton = fixture.debugElement.queryAll(By.css('button'))[0];
+    expect(prevButton.nativeElement.disabled).toBeTruthy();
+  });
+
+  it('should enable next button when not on last page', () => {
+    const nextButton = fixture.debugElement.queryAll(By.css('button'))[1];
+    expect(nextButton.nativeElement.disabled).toBeFalsy();
+  });
+
+  it('should change page when clicking next button', () => {
+    const nextButton = fixture.debugElement.queryAll(By.css('button'))[1];
+    nextButton.nativeElement.click();
+    fixture.detectChanges();
+
+    expect(component.pageIndex).toBe(1);
+    const pageInfo = fixture.debugElement.query(By.css('span.text-gray-500')).nativeElement;
+    expect(pageInfo.textContent.trim()).toBe('11 – 20 of 100');
+  });
+
+  it('should change page when clicking previous button', () => {
+    component.pageIndex = 1;
+    fixture.detectChanges();
+
+    const prevButton = fixture.debugElement.queryAll(By.css('button'))[0];
+    prevButton.nativeElement.click();
+    fixture.detectChanges();
+
+    expect(component.pageIndex).toBe(0);
+    const pageInfo = fixture.debugElement.query(By.css('span.text-gray-500')).nativeElement;
+    expect(pageInfo.textContent.trim()).toBe('1 – 10 of 100');
+  });
+
+  it('should change page size when selecting new value', () => {
+    const selectElement = fixture.debugElement.query(By.css('select')).nativeElement;
+    selectElement.value = '50';
+    selectElement.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    expect(component.pageSize).toBe(50);
+    expect(component.pageIndex).toBe(0);
+    const pageInfo = fixture.debugElement.query(By.css('span.text-gray-500')).nativeElement;
+    expect(pageInfo.textContent.trim()).toBe('1 – 50 of 100');
+  });
+
+  it('should disable next button on last page', () => {
+    component.pageIndex = component.totalPages - 1;
+    fixture.detectChanges();
+
+    const nextButton = fixture.debugElement.queryAll(By.css('button'))[1];
+    expect(nextButton.nativeElement.disabled).toBeTruthy();
+  });
+
+  it('should emit pageChange when changing page', () => {
+    jest.spyOn(component.pageChange, 'emit');
+
+    component.changePage(2);
+    fixture.detectChanges();
+
+    expect(component.pageChange.emit).toHaveBeenCalledWith(2);
+  });
+
+  it('should emit pageSizeChange when changing page size', () => {
+    jest.spyOn(component.pageSizeChange, 'emit');
+
+    component.changePageSize({ target: { value: '50' } } as unknown as Event);
+    fixture.detectChanges();
+
+    expect(component.pageSizeChange.emit).toHaveBeenCalledWith(50);
+  });
+});

--- a/libs/ngx-tailwind-flex-ui/src/lib/paginator/paginator.component.stories.ts
+++ b/libs/ngx-tailwind-flex-ui/src/lib/paginator/paginator.component.stories.ts
@@ -1,0 +1,28 @@
+import { Meta, StoryObj, moduleMetadata } from '@storybook/angular';
+import { PaginatorComponent } from './paginator.component';
+import { CommonModule } from '@angular/common';
+
+export default {
+  title: 'Components/Paginator',
+  component: PaginatorComponent,
+  standalone: true,
+  decorators: [
+    moduleMetadata({
+      imports: [CommonModule],
+    }),
+  ],
+  argTypes: {
+    length: { control: { type: 'number', min: 1 }, description: 'Total number of items' },
+    pageSize: { control: { type: 'number', min: 1 }, description: 'Items per page' },
+    pageIndex: { control: { type: 'number', min: 0 }, description: 'Current page index' },
+    pageChange: { action: 'pageChange', description: 'Emits when the page changes' },
+  },
+} as Meta<PaginatorComponent>;
+
+export const Default: StoryObj<PaginatorComponent> = {
+  args: {
+    length: 100,
+    pageSize: 10,
+    pageIndex: 0,
+  },
+};

--- a/libs/ngx-tailwind-flex-ui/src/lib/paginator/paginator.component.ts
+++ b/libs/ngx-tailwind-flex-ui/src/lib/paginator/paginator.component.ts
@@ -1,0 +1,56 @@
+import { Component, EventEmitter, HostBinding, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'lib-paginator',
+  imports: [CommonModule],
+  templateUrl: './paginator.component.html',
+})
+export class PaginatorComponent {
+  @Input() length = 100; // Total items
+  @Input() pageSize = 10; // Items per page
+  @Input() pageIndex = 0; // Current page
+  @Output() pageChange = new EventEmitter<number>();
+  @Output() pageSizeChange = new EventEmitter<number>();
+
+  pageSizeOptions = [10, 20, 50, 100];
+
+  @HostBinding('class') get hostClasses() {
+    return 'flex justify-between items-center p-4 bg-gray-100 rounded-lg shadow-sm w-full';
+  }
+
+  get totalPages(): number {
+    return Math.ceil(this.length / this.pageSize);
+  }
+
+  get isFirstPage(): boolean {
+    return this.pageIndex === 0;
+  }
+
+  get isLastPage(): boolean {
+    return this.pageIndex === this.totalPages - 1;
+  }
+
+  get startItem(): number {
+    return this.pageIndex * this.pageSize + 1;
+  }
+
+  get endItem(): number {
+    return Math.min((this.pageIndex + 1) * this.pageSize, this.length);
+  }
+
+  changePage(newIndex: number) {
+    if (newIndex >= 0 && newIndex < this.totalPages) {
+      this.pageIndex = newIndex;
+      this.pageChange.emit(this.pageIndex);
+    }
+  }
+
+  changePageSize(event: Event) {
+    const newSize = Number((event.target as HTMLSelectElement).value);
+    this.pageSize = newSize;
+    this.pageIndex = 0; // Reset to first page
+    this.pageSizeChange.emit(this.pageSize);
+    this.pageChange.emit(this.pageIndex);
+  }
+}


### PR DESCRIPTION
![Screenshot 2025-03-12 at 17 29 36](https://github.com/user-attachments/assets/c61a35f4-ca5a-495c-9a25-b7e8e4a63aba)

- Implemented a standalone paginator component that enables navigation through paginated data. The component provides Next, Previous buttons, a dropdown to select page size, with a page counter and with support dynamic page limits.
- Create Storybook stories showcasing paginator component.
- Add unit tests for component rendering and class binding.