### PR TITLE
chore(deps-dev): upgrade @angular-devkit/build-angular to 19.2.5

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -27,8 +27,8 @@ jobs:
             ci
             build
           requireScope: false
-          subjectPattern: "^(?!.*(fix|update|change|improve|enhance|cleanup|workaround)$).*$"
-          subjectPatternError: "PR titles should be specific and follow Conventional Commits."
+          subjectPattern: '^(?!.*(fix|update|change|improve|enhance|cleanup|workaround)$).*$'
+          subjectPatternError: 'PR titles should be specific and follow Conventional Commits.'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: "npm"
+          cache: 'npm'
       - run: npm ci --legacy-peer-deps
       - name: Run affected lint
         run: npx nx affected -t lint --base=origin/${{ github.base_ref }} --head=${{ github.event.pull_request.head.sha }}
@@ -95,8 +95,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: "npm"
+          cache: 'npm'
       - run: npm ci --legacy-peer-deps
+      - name: Install playwright browsers
+        run: npx playwright install --with-deps
       - name: Run affected tests
         run: npx nx affected -t test e2e --base=origin/${{ github.base_ref }} --head=${{ github.event.pull_request.head.sha }}
         continue-on-error: false
@@ -122,7 +124,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: "npm"
+          cache: 'npm'
       - run: npm ci --legacy-peer-deps
       - name: Check if Storybook builds
         run: npx nx affected -t build-storybook --base=origin/${{ github.base_ref }} --head=${{ github.event.pull_request.head.sha }}

--- a/apps/playground-e2e/src/example.spec.ts
+++ b/apps/playground-e2e/src/example.spec.ts
@@ -4,5 +4,7 @@ test('has title', async ({ page }) => {
   await page.goto('/');
 
   // Expect h1 to contain a substring.
-  expect(await page.locator('h1').innerText()).toContain('Welcome');
+  expect(await page.locator('h1').innerText()).toContain(
+    'Button Component Showcase'
+  );
 });

--- a/apps/playground/src/app/app.component.spec.ts
+++ b/apps/playground/src/app/app.component.spec.ts
@@ -10,15 +10,6 @@ describe('AppComponent', () => {
     }).compileComponents();
   });
 
-  it('should render title', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain(
-      'Welcome playground'
-    );
-  });
-
   it(`should have as title 'playground'`, () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;

--- a/apps/playground/src/app/components/icon-demo/icon-demo.component.html
+++ b/apps/playground/src/app/components/icon-demo/icon-demo.component.html
@@ -92,29 +92,6 @@
   <section class="mb-12">
     <h2 class="text-2xl font-semibold mb-4 pb-2 border-b">Interactive Example</h2>
     <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
-      <!-- Icon Selector -->
-      <div class="p-4 border rounded-lg">
-        <h3 class="text-lg font-medium mb-3">Icon Selector</h3>
-        <div class="flex flex-col gap-4">
-          <p class="text-gray-600">Click on an icon to select it:</p>
-          <div class="grid grid-cols-5 gap-4">
-            <div *ngFor="let icon of commonIcons.slice(0, 10)"
-                 class="p-2 border rounded-md cursor-pointer hover:bg-gray-100 flex flex-col items-center gap-1"
-                 [class.bg-blue-100]="selectedIcon === icon"
-                 (click)="selectIcon(icon)">
-              <lib-icon [name]="icon"></lib-icon>
-              <span class="text-xs">{{icon}}</span>
-            </div>
-          </div>
-          <div class="mt-4 p-4 border rounded-md bg-gray-50 flex items-center justify-center">
-            <div class="flex flex-col items-center gap-2">
-              <lib-icon [name]="selectedIcon" size="xl" color="text-blue-600"></lib-icon>
-              <span class="text-sm">Selected: {{selectedIcon}}</span>
-            </div>
-          </div>
-        </div>
-      </div>
-
       <!-- Animation Example -->
       <div class="p-4 border rounded-lg">
         <h3 class="text-lg font-medium mb-3">Animation Example</h3>

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "zone.js": "^0.15.0"
       },
       "devDependencies": {
-        "@angular-devkit/build-angular": "~19.1.0",
+        "@angular-devkit/build-angular": "~19.2.5",
         "@angular-devkit/core": "~19.1.0",
         "@angular-devkit/schematics": "~19.1.0",
         "@angular/cli": "~19.1.0",
@@ -33,7 +33,7 @@
         "@module-federation/enhanced": "^0.9.1",
         "@module-federation/manifest": "^0.9.1",
         "@module-federation/rspack": "^0.9.1",
-        "@nx/angular": "20.4.6",
+        "@nx/angular": "^20.4.6",
         "@nx/devkit": "20.4.6",
         "@nx/eslint": "20.4.6",
         "@nx/eslint-plugin": "20.4.6",
@@ -128,13 +128,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1902.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1902.0.tgz",
-      "integrity": "sha512-F/3O38QOYCwNqECNQauKb56GYdST9SrRSiqTNc5xpnUL//A09kaucmKSZ2VJAVY7K/rktSQn5viiQ3rTJLiZgA==",
+      "version": "0.1902.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1902.5.tgz",
+      "integrity": "sha512-GdcTqwCZT0CTagUoTmq799hpnbQeICx53+eHsfs+lyKjkojk1ahC6ZOi4nNLDl/J2DIMFPHIG1ZgHPuhjKItAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.2.0",
+        "@angular-devkit/core": "19.2.5",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -144,9 +144,9 @@
       }
     },
     "node_modules/@angular-devkit/architect/node_modules/@angular-devkit/core": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.0.tgz",
-      "integrity": "sha512-qd2nYoHZOYWRsu4MjXG8KiDtfM9ZDRR2rDGa+rDZ3CYAsngCrPmqOebun10dncUjwAidX49P4S2U2elOmX3VYQ==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.5.tgz",
+      "integrity": "sha512-s5d6ZQmut5QO7pcxssIoDgeVhVEjoQKxWpBeqsSdYxMYjROMR+QnlNcyiSDLI6Wc7QR9mZINOpx8yoj6Nim1Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -182,28 +182,28 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "19.1.9",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-19.1.9.tgz",
-      "integrity": "sha512-Y2ohbcGEsceiNO5B11C0sbEXUhx+Z6+9nAV5GyySMXZ/GDE2cfvxc8deB0CK+bnlI0diz9ZOdJt6a65LBJ7Tnw==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-19.2.5.tgz",
+      "integrity": "sha512-PmLAaPuruTzEACsVe7MVyDuShQhyFdj83gWqvPKXVd8p2SIEE8SeVXyNRKNYf84cZdxqJB+IgjyvTPK7R7a+rA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1901.9",
-        "@angular-devkit/build-webpack": "0.1901.9",
-        "@angular-devkit/core": "19.1.9",
-        "@angular/build": "19.1.9",
-        "@babel/core": "7.26.0",
-        "@babel/generator": "7.26.3",
+        "@angular-devkit/architect": "0.1902.5",
+        "@angular-devkit/build-webpack": "0.1902.5",
+        "@angular-devkit/core": "19.2.5",
+        "@angular/build": "19.2.5",
+        "@babel/core": "7.26.10",
+        "@babel/generator": "7.26.10",
         "@babel/helper-annotate-as-pure": "7.25.9",
         "@babel/helper-split-export-declaration": "7.24.7",
-        "@babel/plugin-transform-async-generator-functions": "7.25.9",
+        "@babel/plugin-transform-async-generator-functions": "7.26.8",
         "@babel/plugin-transform-async-to-generator": "7.25.9",
-        "@babel/plugin-transform-runtime": "7.25.9",
-        "@babel/preset-env": "7.26.0",
-        "@babel/runtime": "7.26.0",
+        "@babel/plugin-transform-runtime": "7.26.10",
+        "@babel/preset-env": "7.26.9",
+        "@babel/runtime": "7.26.10",
         "@discoveryjs/json-ext": "0.6.3",
-        "@ngtools/webpack": "19.1.9",
+        "@ngtools/webpack": "19.2.5",
         "@vitejs/plugin-basic-ssl": "1.2.0",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.20",
@@ -211,13 +211,13 @@
         "browserslist": "^4.21.5",
         "copy-webpack-plugin": "12.0.2",
         "css-loader": "7.1.2",
-        "esbuild-wasm": "0.24.2",
+        "esbuild-wasm": "0.25.1",
         "fast-glob": "3.3.3",
         "http-proxy-middleware": "3.0.3",
         "istanbul-lib-instrument": "6.0.3",
         "jsonc-parser": "3.3.1",
         "karma-source-map-support": "1.4.0",
-        "less": "4.2.1",
+        "less": "4.2.2",
         "less-loader": "12.2.0",
         "license-webpack-plugin": "4.0.2",
         "loader-utils": "3.3.1",
@@ -226,19 +226,19 @@
         "ora": "5.4.1",
         "picomatch": "4.0.2",
         "piscina": "4.8.0",
-        "postcss": "8.4.49",
+        "postcss": "8.5.2",
         "postcss-loader": "8.1.1",
         "resolve-url-loader": "5.0.0",
         "rxjs": "7.8.1",
-        "sass": "1.83.1",
-        "sass-loader": "16.0.4",
-        "semver": "7.6.3",
+        "sass": "1.85.0",
+        "sass-loader": "16.0.5",
+        "semver": "7.7.1",
         "source-map-loader": "5.0.0",
         "source-map-support": "0.5.21",
-        "terser": "5.37.0",
+        "terser": "5.39.0",
         "tree-kill": "1.2.2",
         "tslib": "2.8.1",
-        "webpack": "5.97.1",
+        "webpack": "5.98.0",
         "webpack-dev-middleware": "7.4.2",
         "webpack-dev-server": "5.2.0",
         "webpack-merge": "6.0.1",
@@ -250,23 +250,23 @@
         "yarn": ">= 1.13.0"
       },
       "optionalDependencies": {
-        "esbuild": "0.24.2"
+        "esbuild": "0.25.1"
       },
       "peerDependencies": {
-        "@angular/compiler-cli": "^19.0.0",
-        "@angular/localize": "^19.0.0",
-        "@angular/platform-server": "^19.0.0",
-        "@angular/service-worker": "^19.0.0",
-        "@angular/ssr": "^19.1.9",
-        "@web/test-runner": "^0.19.0",
+        "@angular/compiler-cli": "^19.0.0 || ^19.2.0-next.0",
+        "@angular/localize": "^19.0.0 || ^19.2.0-next.0",
+        "@angular/platform-server": "^19.0.0 || ^19.2.0-next.0",
+        "@angular/service-worker": "^19.0.0 || ^19.2.0-next.0",
+        "@angular/ssr": "^19.2.5",
+        "@web/test-runner": "^0.20.0",
         "browser-sync": "^3.0.2",
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
         "karma": "^6.3.0",
-        "ng-packagr": "^19.0.0",
+        "ng-packagr": "^19.0.0 || ^19.2.0-next.0",
         "protractor": "^7.0.0",
         "tailwindcss": "^2.0.0 || ^3.0.0 || ^4.0.0",
-        "typescript": ">=5.5 <5.8"
+        "typescript": ">=5.5 <5.9"
       },
       "peerDependenciesMeta": {
         "@angular/localize": {
@@ -307,54 +307,66 @@
         }
       }
     },
-    "node_modules/@angular-devkit/build-angular/node_modules/@angular-devkit/architect": {
-      "version": "0.1901.9",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1901.9.tgz",
-      "integrity": "sha512-Z5H7s9X2bIWTvhGllO7kDqbgNnn8r78senlLquyc8sMIC1vQ4EQE+nzUSDtfp7tHqWeiK8Gk7eTWTL+UM9rXmw==",
+    "node_modules/@angular-devkit/build-angular/node_modules/@angular-devkit/core": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.5.tgz",
+      "integrity": "sha512-s5d6ZQmut5QO7pcxssIoDgeVhVEjoQKxWpBeqsSdYxMYjROMR+QnlNcyiSDLI6Wc7QR9mZINOpx8yoj6Nim1Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.1.9",
-        "rxjs": "7.8.1"
+        "ajv": "8.17.1",
+        "ajv-formats": "3.0.1",
+        "jsonc-parser": "3.3.1",
+        "picomatch": "4.0.2",
+        "rxjs": "7.8.1",
+        "source-map": "0.7.4"
       },
       "engines": {
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@angular/build": {
-      "version": "19.1.9",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-19.1.9.tgz",
-      "integrity": "sha512-YIdIE4ogZytEPKVysNnS1l3cBIYa6e/MRFeOPyLmXm0Rhl3XmlxHMnz8Go+8oT4SjVM7d2puboc/I0MMK2D/HA==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-19.2.5.tgz",
+      "integrity": "sha512-WtgdBHxFVMtbLzEYf1dYJqtld282aXxEbefsRi3RZWnLya8qO33bKMxpcd0V2iLIuIc1v/sUXPIzbWLO10mvTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1901.9",
-        "@angular-devkit/core": "19.1.9",
-        "@babel/core": "7.26.0",
+        "@angular-devkit/architect": "0.1902.5",
+        "@babel/core": "7.26.10",
         "@babel/helper-annotate-as-pure": "7.25.9",
         "@babel/helper-split-export-declaration": "7.24.7",
         "@babel/plugin-syntax-import-attributes": "7.26.0",
-        "@inquirer/confirm": "5.1.1",
+        "@inquirer/confirm": "5.1.6",
         "@vitejs/plugin-basic-ssl": "1.2.0",
         "beasties": "0.2.0",
         "browserslist": "^4.23.0",
-        "esbuild": "0.24.2",
+        "esbuild": "0.25.1",
         "fast-glob": "3.3.3",
         "https-proxy-agent": "7.0.6",
         "istanbul-lib-instrument": "6.0.3",
         "listr2": "8.2.5",
         "magic-string": "0.30.17",
-        "mrmime": "2.0.0",
+        "mrmime": "2.0.1",
         "parse5-html-rewriting-stream": "7.0.0",
         "picomatch": "4.0.2",
         "piscina": "4.8.0",
-        "rollup": "4.30.1",
-        "sass": "1.83.1",
-        "semver": "7.6.3",
-        "vite": "6.0.11",
+        "rollup": "4.34.8",
+        "sass": "1.85.0",
+        "semver": "7.7.1",
+        "source-map-support": "0.5.21",
+        "vite": "6.2.3",
         "watchpack": "2.4.2"
       },
       "engines": {
@@ -363,20 +375,21 @@
         "yarn": ">= 1.13.0"
       },
       "optionalDependencies": {
-        "lmdb": "3.2.2"
+        "lmdb": "3.2.6"
       },
       "peerDependencies": {
-        "@angular/compiler": "^19.0.0",
-        "@angular/compiler-cli": "^19.0.0",
-        "@angular/localize": "^19.0.0",
-        "@angular/platform-server": "^19.0.0",
-        "@angular/service-worker": "^19.0.0",
-        "@angular/ssr": "^19.1.9",
+        "@angular/compiler": "^19.0.0 || ^19.2.0-next.0",
+        "@angular/compiler-cli": "^19.0.0 || ^19.2.0-next.0",
+        "@angular/localize": "^19.0.0 || ^19.2.0-next.0",
+        "@angular/platform-server": "^19.0.0 || ^19.2.0-next.0",
+        "@angular/service-worker": "^19.0.0 || ^19.2.0-next.0",
+        "@angular/ssr": "^19.2.5",
+        "karma": "^6.4.0",
         "less": "^4.2.0",
-        "ng-packagr": "^19.0.0",
+        "ng-packagr": "^19.0.0 || ^19.2.0-next.0",
         "postcss": "^8.4.0",
         "tailwindcss": "^2.0.0 || ^3.0.0 || ^4.0.0",
-        "typescript": ">=5.5 <5.8"
+        "typescript": ">=5.5 <5.9"
       },
       "peerDependenciesMeta": {
         "@angular/localize": {
@@ -389,6 +402,9 @@
           "optional": true
         },
         "@angular/ssr": {
+          "optional": true
+        },
+        "karma": {
           "optional": true
         },
         "less": {
@@ -405,99 +421,51 @@
         }
       }
     },
-    "node_modules/@angular-devkit/build-angular/node_modules/@angular/build/node_modules/vite": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.11.tgz",
-      "integrity": "sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==",
+    "node_modules/@angular-devkit/build-angular/node_modules/@babel/core": {
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
+      "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.24.2",
-        "postcss": "^8.4.49",
-        "rollup": "^4.23.0"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.26.10",
+        "@babel/helper-compilation-targets": "^7.26.5",
+        "@babel/helper-module-transforms": "^7.26.0",
+        "@babel/helpers": "^7.26.10",
+        "@babel/parser": "^7.26.10",
+        "@babel/template": "^7.26.9",
+        "@babel/traverse": "^7.26.10",
+        "@babel/types": "^7.26.10",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": ">=6.9.0"
       },
       "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "jiti": ">=1.21.0",
-        "less": "*",
-        "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@angular-devkit/build-angular/node_modules/@inquirer/confirm": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.1.tgz",
-      "integrity": "sha512-vVLSbGci+IKQvDOtzpPTCOiEJCNidHcAq9JYVoWTW0svb5FiwSLotkM+JXNXejfjnzVYV9n0DTBythl9+XgTxg==",
+    "node_modules/@angular-devkit/build-angular/node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.1.2",
-        "@inquirer/type": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.30.1.tgz",
-      "integrity": "sha512-pSWY+EVt3rJ9fQ3IqlrEUtXh3cGqGtPDH1FQlNZehO2yYxCHEX1SPsz1M//NXwYfbTlcKr9WObLnJX9FsS9K1Q==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.8.tgz",
+      "integrity": "sha512-q217OSE8DTp8AFHuNHXo0Y86e1wtlfVrXiAlwkIvGRQv9zbc6mE3sjIVfwI8sYUyNxwOg0j/Vm1RKM04JcWLJw==",
       "cpu": [
         "arm"
       ],
@@ -509,9 +477,9 @@
       ]
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.30.1.tgz",
-      "integrity": "sha512-/NA2qXxE3D/BRjOJM8wQblmArQq1YoBVJjrjoTSBS09jgUisq7bqxNHJ8kjCHeV21W/9WDGwJEWSN0KQ2mtD/w==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.34.8.tgz",
+      "integrity": "sha512-Gigjz7mNWaOL9wCggvoK3jEIUUbGul656opstjaUSGC3eT0BM7PofdAJaBfPFWWkXNVAXbaQtC99OCg4sJv70Q==",
       "cpu": [
         "arm64"
       ],
@@ -523,9 +491,9 @@
       ]
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.30.1.tgz",
-      "integrity": "sha512-r7FQIXD7gB0WJ5mokTUgUWPl0eYIH0wnxqeSAhuIwvnnpjdVB8cRRClyKLQr7lgzjctkbp5KmswWszlwYln03Q==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.34.8.tgz",
+      "integrity": "sha512-02rVdZ5tgdUNRxIUrFdcMBZQoaPMrxtwSb+/hOfBdqkatYHR3lZ2A2EGyHq2sGOd0Owk80oV3snlDASC24He3Q==",
       "cpu": [
         "arm64"
       ],
@@ -537,9 +505,9 @@
       ]
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.30.1.tgz",
-      "integrity": "sha512-x78BavIwSH6sqfP2xeI1hd1GpHL8J4W2BXcVM/5KYKoAD3nNsfitQhvWSw+TFtQTLZ9OmlF+FEInEHyubut2OA==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.34.8.tgz",
+      "integrity": "sha512-qIP/elwR/tq/dYRx3lgwK31jkZvMiD6qUtOycLhTzCvrjbZ3LjQnEM9rNhSGpbLXVJYQ3rq39A6Re0h9tU2ynw==",
       "cpu": [
         "x64"
       ],
@@ -551,9 +519,9 @@
       ]
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.30.1.tgz",
-      "integrity": "sha512-HYTlUAjbO1z8ywxsDFWADfTRfTIIy/oUlfIDmlHYmjUP2QRDTzBuWXc9O4CXM+bo9qfiCclmHk1x4ogBjOUpUQ==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.34.8.tgz",
+      "integrity": "sha512-IQNVXL9iY6NniYbTaOKdrlVP3XIqazBgJOVkddzJlqnCpRi/yAeSOa8PLcECFSQochzqApIOE1GHNu3pCz+BDA==",
       "cpu": [
         "arm64"
       ],
@@ -565,9 +533,9 @@
       ]
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.30.1.tgz",
-      "integrity": "sha512-1MEdGqogQLccphhX5myCJqeGNYTNcmTyaic9S7CG3JhwuIByJ7J05vGbZxsizQthP1xpVx7kd3o31eOogfEirw==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.34.8.tgz",
+      "integrity": "sha512-TYXcHghgnCqYFiE3FT5QwXtOZqDj5GmaFNTNt3jNC+vh22dc/ukG2cG+pi75QO4kACohZzidsq7yKTKwq/Jq7Q==",
       "cpu": [
         "x64"
       ],
@@ -579,9 +547,9 @@
       ]
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.30.1.tgz",
-      "integrity": "sha512-PaMRNBSqCx7K3Wc9QZkFx5+CX27WFpAMxJNiYGAXfmMIKC7jstlr32UhTgK6T07OtqR+wYlWm9IxzennjnvdJg==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.34.8.tgz",
+      "integrity": "sha512-A4iphFGNkWRd+5m3VIGuqHnG3MVnqKe7Al57u9mwgbyZ2/xF9Jio72MaY7xxh+Y87VAHmGQr73qoKL9HPbXj1g==",
       "cpu": [
         "arm"
       ],
@@ -593,9 +561,9 @@
       ]
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.30.1.tgz",
-      "integrity": "sha512-B8Rcyj9AV7ZlEFqvB5BubG5iO6ANDsRKlhIxySXcF1axXYUyqwBok+XZPgIYGBgs7LDXfWfifxhw0Ik57T0Yug==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.34.8.tgz",
+      "integrity": "sha512-S0lqKLfTm5u+QTxlFiAnb2J/2dgQqRy/XvziPtDd1rKZFXHTyYLoVL58M/XFwDI01AQCDIevGLbQrMAtdyanpA==",
       "cpu": [
         "arm"
       ],
@@ -607,9 +575,9 @@
       ]
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.30.1.tgz",
-      "integrity": "sha512-hqVyueGxAj3cBKrAI4aFHLV+h0Lv5VgWZs9CUGqr1z0fZtlADVV1YPOij6AhcK5An33EXaxnDLmJdQikcn5NEw==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.34.8.tgz",
+      "integrity": "sha512-jpz9YOuPiSkL4G4pqKrus0pn9aYwpImGkosRKwNi+sJSkz+WU3anZe6hi73StLOQdfXYXC7hUfsQlTnjMd3s1A==",
       "cpu": [
         "arm64"
       ],
@@ -621,9 +589,9 @@
       ]
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.30.1.tgz",
-      "integrity": "sha512-i4Ab2vnvS1AE1PyOIGp2kXni69gU2DAUVt6FSXeIqUCPIR3ZlheMW3oP2JkukDfu3PsexYRbOiJrY+yVNSk9oA==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.34.8.tgz",
+      "integrity": "sha512-KdSfaROOUJXgTVxJNAZ3KwkRc5nggDk+06P6lgi1HLv1hskgvxHUKZ4xtwHkVYJ1Rep4GNo+uEfycCRRxht7+Q==",
       "cpu": [
         "arm64"
       ],
@@ -635,9 +603,9 @@
       ]
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.30.1.tgz",
-      "integrity": "sha512-fARcF5g296snX0oLGkVxPmysetwUk2zmHcca+e9ObOovBR++9ZPOhqFUM61UUZ2EYpXVPN1redgqVoBB34nTpQ==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.8.tgz",
+      "integrity": "sha512-NyF4gcxwkMFRjgXBM6g2lkT58OWztZvw5KkV2K0qqSnUEqCVcqdh2jN4gQrTn/YUpAcNKyFHfoOZEer9nwo6uQ==",
       "cpu": [
         "loong64"
       ],
@@ -649,9 +617,9 @@
       ]
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.30.1.tgz",
-      "integrity": "sha512-GLrZraoO3wVT4uFXh67ElpwQY0DIygxdv0BNW9Hkm3X34wu+BkqrDrkcsIapAY+N2ATEbvak0XQ9gxZtCIA5Rw==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.34.8.tgz",
+      "integrity": "sha512-LMJc999GkhGvktHU85zNTDImZVUCJ1z/MbAJTnviiWmmjyckP5aQsHtcujMjpNdMZPT2rQEDBlJfubhs3jsMfw==",
       "cpu": [
         "ppc64"
       ],
@@ -663,9 +631,9 @@
       ]
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.30.1.tgz",
-      "integrity": "sha512-0WKLaAUUHKBtll0wvOmh6yh3S0wSU9+yas923JIChfxOaaBarmb/lBKPF0w/+jTVozFnOXJeRGZ8NvOxvk/jcw==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.34.8.tgz",
+      "integrity": "sha512-xAQCAHPj8nJq1PI3z8CIZzXuXCstquz7cIOL73HHdXiRcKk8Ywwqtx2wrIy23EcTn4aZ2fLJNBB8d0tQENPCmw==",
       "cpu": [
         "riscv64"
       ],
@@ -677,9 +645,9 @@
       ]
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.30.1.tgz",
-      "integrity": "sha512-GWFs97Ruxo5Bt+cvVTQkOJ6TIx0xJDD/bMAOXWJg8TCSTEK8RnFeOeiFTxKniTc4vMIaWvCplMAFBt9miGxgkA==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.34.8.tgz",
+      "integrity": "sha512-DdePVk1NDEuc3fOe3dPPTb+rjMtuFw89gw6gVWxQFAuEqqSdDKnrwzZHrUYdac7A7dXl9Q2Vflxpme15gUWQFA==",
       "cpu": [
         "s390x"
       ],
@@ -691,9 +659,9 @@
       ]
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.30.1.tgz",
-      "integrity": "sha512-UtgGb7QGgXDIO+tqqJ5oZRGHsDLO8SlpE4MhqpY9Llpzi5rJMvrK6ZGhsRCST2abZdBqIBeXW6WPD5fGK5SDwg==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.8.tgz",
+      "integrity": "sha512-8y7ED8gjxITUltTUEJLQdgpbPh1sUQ0kMTmufRF/Ns5tI9TNMNlhWtmPKKHCU0SilX+3MJkZ0zERYYGIVBYHIA==",
       "cpu": [
         "x64"
       ],
@@ -705,9 +673,9 @@
       ]
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.30.1.tgz",
-      "integrity": "sha512-V9U8Ey2UqmQsBT+xTOeMzPzwDzyXmnAoO4edZhL7INkwQcaW1Ckv3WJX3qrrp/VHaDkEWIBWhRwP47r8cdrOow==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.8.tgz",
+      "integrity": "sha512-SCXcP0ZpGFIe7Ge+McxY5zKxiEI5ra+GT3QRxL0pMMtxPfpyLAKleZODi1zdRHkz5/BhueUrYtYVgubqe9JBNQ==",
       "cpu": [
         "x64"
       ],
@@ -719,9 +687,9 @@
       ]
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.30.1.tgz",
-      "integrity": "sha512-WabtHWiPaFF47W3PkHnjbmWawnX/aE57K47ZDT1BXTS5GgrBUEpvOzq0FI0V/UYzQJgdb8XlhVNH8/fwV8xDjw==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.34.8.tgz",
+      "integrity": "sha512-YHYsgzZgFJzTRbth4h7Or0m5O74Yda+hLin0irAIobkLQFRQd1qWmnoVfwmKm9TXIZVAD0nZ+GEb2ICicLyCnQ==",
       "cpu": [
         "arm64"
       ],
@@ -733,9 +701,9 @@
       ]
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.30.1.tgz",
-      "integrity": "sha512-pxHAU+Zv39hLUTdQQHUVHf4P+0C47y/ZloorHpzs2SXMRqeAWmGghzAhfOlzFHHwjvgokdFAhC4V+6kC1lRRfw==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.34.8.tgz",
+      "integrity": "sha512-r3NRQrXkHr4uWy5TOjTpTYojR9XmF0j/RYgKCef+Ag46FWUTltm5ziticv8LdNsDMehjJ543x/+TJAek/xBA2w==",
       "cpu": [
         "ia32"
       ],
@@ -747,9 +715,9 @@
       ]
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.30.1.tgz",
-      "integrity": "sha512-D6qjsXGcvhTjv0kI4fU8tUuBDF/Ueee4SVX79VfNDXZa64TfCW1Slkb6Z7O1p7vflqZjcmOVdZlqf8gvJxc6og==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.8.tgz",
+      "integrity": "sha512-U0FaE5O1BCpZSeE6gBl3c5ObhePQSfk9vDRToMmTkbhCOgW4jqvtS5LGyQ76L1fH8sM0keRp4uDTsbjiUyjk0g==",
       "cpu": [
         "x64"
       ],
@@ -770,6 +738,13 @@
         "node": ">= 14"
       }
     },
+    "node_modules/@angular-devkit/build-angular/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@angular-devkit/build-angular/node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -785,9 +760,9 @@
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/postcss": {
-      "version": "8.4.49",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.2.tgz",
+      "integrity": "sha512-MjOadfU3Ys9KYoX0AdkBlFEF1Vx37uCCeN4ZHnmwm9FfpbsGWMZeBLMmmpY+6Ocqod7mkdZ0DT31OlbsFrLlkA==",
       "dev": true,
       "funding": [
         {
@@ -805,7 +780,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
+        "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -814,9 +789,9 @@
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/rollup": {
-      "version": "4.30.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.30.1.tgz",
-      "integrity": "sha512-mlJ4glW020fPuLi7DkM/lN97mYEZGWeqBnrljzN0gs7GLctqX3lNWxKQ7Gl712UAX+6fog/L3jh4gb7R6aVi3w==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.8.tgz",
+      "integrity": "sha512-489gTVMzAYdiZHFVA/ig/iYFllCcWFHMvUHI1rpFmkoUtRlQxqh6/yiNqnYibjMZ2b/+FUQwldG+aLsEt6bglQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -830,25 +805,25 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.30.1",
-        "@rollup/rollup-android-arm64": "4.30.1",
-        "@rollup/rollup-darwin-arm64": "4.30.1",
-        "@rollup/rollup-darwin-x64": "4.30.1",
-        "@rollup/rollup-freebsd-arm64": "4.30.1",
-        "@rollup/rollup-freebsd-x64": "4.30.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.30.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.30.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.30.1",
-        "@rollup/rollup-linux-arm64-musl": "4.30.1",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.30.1",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.30.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.30.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.30.1",
-        "@rollup/rollup-linux-x64-gnu": "4.30.1",
-        "@rollup/rollup-linux-x64-musl": "4.30.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.30.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.30.1",
-        "@rollup/rollup-win32-x64-msvc": "4.30.1",
+        "@rollup/rollup-android-arm-eabi": "4.34.8",
+        "@rollup/rollup-android-arm64": "4.34.8",
+        "@rollup/rollup-darwin-arm64": "4.34.8",
+        "@rollup/rollup-darwin-x64": "4.34.8",
+        "@rollup/rollup-freebsd-arm64": "4.34.8",
+        "@rollup/rollup-freebsd-x64": "4.34.8",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.34.8",
+        "@rollup/rollup-linux-arm-musleabihf": "4.34.8",
+        "@rollup/rollup-linux-arm64-gnu": "4.34.8",
+        "@rollup/rollup-linux-arm64-musl": "4.34.8",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.34.8",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.34.8",
+        "@rollup/rollup-linux-riscv64-gnu": "4.34.8",
+        "@rollup/rollup-linux-s390x-gnu": "4.34.8",
+        "@rollup/rollup-linux-x64-gnu": "4.34.8",
+        "@rollup/rollup-linux-x64-musl": "4.34.8",
+        "@rollup/rollup-win32-arm64-msvc": "4.34.8",
+        "@rollup/rollup-win32-ia32-msvc": "4.34.8",
+        "@rollup/rollup-win32-x64-msvc": "4.34.8",
         "fsevents": "~2.3.2"
       }
     },
@@ -862,14 +837,27 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@angular-devkit/build-angular/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1901.9",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1901.9.tgz",
-      "integrity": "sha512-Q5fZI1UTnth5LRColCCBIXssBr2/TNoJkuANd/cqNLcYNJehlSDfOOiEmRKTiH2Ytof2GvBclmt4+twL+clTfg==",
+      "version": "0.1902.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1902.5.tgz",
+      "integrity": "sha512-rXvUKRAgjhHTmBVr4HbZs+gS6sQ5EM+sv+Ygzl7oz7xC2+JOKBYiq+9B8Udk4GnW3Es9m6Dq7G4XbBMPzVia3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.1901.9",
+        "@angular-devkit/architect": "0.1902.5",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -880,22 +868,6 @@
       "peerDependencies": {
         "webpack": "^5.30.0",
         "webpack-dev-server": "^5.0.2"
-      }
-    },
-    "node_modules/@angular-devkit/build-webpack/node_modules/@angular-devkit/architect": {
-      "version": "0.1901.9",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1901.9.tgz",
-      "integrity": "sha512-Z5H7s9X2bIWTvhGllO7kDqbgNnn8r78senlLquyc8sMIC1vQ4EQE+nzUSDtfp7tHqWeiK8Gk7eTWTL+UM9rXmw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@angular-devkit/core": "19.1.9",
-        "rxjs": "7.8.1"
-      },
-      "engines": {
-        "node": "^18.19.1 || ^20.11.1 || >=22.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
       }
     },
     "node_modules/@angular-devkit/build-webpack/node_modules/rxjs": {
@@ -1427,14 +1399,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.3.tgz",
-      "integrity": "sha512-6FF/urZvD0sTeO7k6/B15pMLC4CHUv1426lzr3N01aHJTl046uCAh9LXW/fzeXXjPNCJ6iABW5XaWOsIZB93aQ==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.10.tgz",
+      "integrity": "sha512-rRHT8siFIXQrAYOYqZQVsAr8vJ+cBNqcVAY6m5V8/4QqzaPl+zDBe6cLEPRDuNOUf3ww8RfJVlOyQMoSI+5Ang==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.26.3",
-        "@babel/types": "^7.26.3",
+        "@babel/parser": "^7.26.10",
+        "@babel/types": "^7.26.10",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -1738,27 +1710,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.9.tgz",
-      "integrity": "sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
-      "integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.9"
+        "@babel/types": "^7.27.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -2187,15 +2159,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-generator-functions": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.9.tgz",
-      "integrity": "sha512-RXV6QAzTBbhDMO9fWwOmwwTuYaiPbggWQ9INdZqAYeSHyG7FzQ+nOZaUUjNwKv9pV3aE4WFqFm1Hnbci5tBCAw==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.26.8.tgz",
+      "integrity": "sha512-He9Ej2X7tNf2zdKMAGOsmg2MrFc+hfoAhd3po4cWfo/NWjzEAKa0oQruj1ROVUdl0e6fb6/kE/G3SSxE0lRJOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.26.5",
         "@babel/helper-remap-async-to-generator": "^7.25.9",
-        "@babel/traverse": "^7.25.9"
+        "@babel/traverse": "^7.26.8"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2860,16 +2832,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.25.9.tgz",
-      "integrity": "sha512-nZp7GlEl+yULJrClz0SwHPqir3lc0zsPrDHQUcxGspSL7AKrexNSEfTbfqnDNJUO13bgKyfuOLMF8Xqtu8j3YQ==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.26.10.tgz",
+      "integrity": "sha512-NWaL2qG6HRpONTnj4JvDU6th4jYeZOJgu3QhmFTCihib0ermtOJqktA5BduGm3suhhVe9EMP9c9+mfJ/I9slqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.26.5",
         "babel-plugin-polyfill-corejs2": "^0.4.10",
-        "babel-plugin-polyfill-corejs3": "^0.10.6",
+        "babel-plugin-polyfill-corejs3": "^0.11.0",
         "babel-plugin-polyfill-regenerator": "^0.6.1",
         "semver": "^6.3.1"
       },
@@ -2878,6 +2850,20 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-runtime/node_modules/babel-plugin-polyfill-corejs3": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.11.1.tgz",
+      "integrity": "sha512-yGCqvBT4rwMczo28xkH/noxJ6MZ4nJfkVYdoDaC/utLtWrXxv27HVrzAeSbqR8SxDsp46n0YF47EbHoixy6rXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.6.3",
+        "core-js-compat": "^3.40.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-runtime/node_modules/semver": {
@@ -3059,15 +3045,15 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.26.0.tgz",
-      "integrity": "sha512-H84Fxq0CQJNdPFT2DrfnylZ3cf5K43rGfWK4LJGPpjKHiZlk0/RzwEus3PDDZZg+/Er7lCA03MVacueUuXdzfw==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.26.9.tgz",
+      "integrity": "sha512-vX3qPGE8sEKEAZCWk05k3cpTAE3/nOYca++JA+Rd0z2NCNzabmYvEiSShKzm10zdquOIAVXsy2Ei/DTW34KlKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.26.0",
-        "@babel/helper-compilation-targets": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/compat-data": "^7.26.8",
+        "@babel/helper-compilation-targets": "^7.26.5",
+        "@babel/helper-plugin-utils": "^7.26.5",
         "@babel/helper-validator-option": "^7.25.9",
         "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.25.9",
         "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.25.9",
@@ -3079,9 +3065,9 @@
         "@babel/plugin-syntax-import-attributes": "^7.26.0",
         "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
         "@babel/plugin-transform-arrow-functions": "^7.25.9",
-        "@babel/plugin-transform-async-generator-functions": "^7.25.9",
+        "@babel/plugin-transform-async-generator-functions": "^7.26.8",
         "@babel/plugin-transform-async-to-generator": "^7.25.9",
-        "@babel/plugin-transform-block-scoped-functions": "^7.25.9",
+        "@babel/plugin-transform-block-scoped-functions": "^7.26.5",
         "@babel/plugin-transform-block-scoping": "^7.25.9",
         "@babel/plugin-transform-class-properties": "^7.25.9",
         "@babel/plugin-transform-class-static-block": "^7.26.0",
@@ -3092,21 +3078,21 @@
         "@babel/plugin-transform-duplicate-keys": "^7.25.9",
         "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.25.9",
         "@babel/plugin-transform-dynamic-import": "^7.25.9",
-        "@babel/plugin-transform-exponentiation-operator": "^7.25.9",
+        "@babel/plugin-transform-exponentiation-operator": "^7.26.3",
         "@babel/plugin-transform-export-namespace-from": "^7.25.9",
-        "@babel/plugin-transform-for-of": "^7.25.9",
+        "@babel/plugin-transform-for-of": "^7.26.9",
         "@babel/plugin-transform-function-name": "^7.25.9",
         "@babel/plugin-transform-json-strings": "^7.25.9",
         "@babel/plugin-transform-literals": "^7.25.9",
         "@babel/plugin-transform-logical-assignment-operators": "^7.25.9",
         "@babel/plugin-transform-member-expression-literals": "^7.25.9",
         "@babel/plugin-transform-modules-amd": "^7.25.9",
-        "@babel/plugin-transform-modules-commonjs": "^7.25.9",
+        "@babel/plugin-transform-modules-commonjs": "^7.26.3",
         "@babel/plugin-transform-modules-systemjs": "^7.25.9",
         "@babel/plugin-transform-modules-umd": "^7.25.9",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.25.9",
         "@babel/plugin-transform-new-target": "^7.25.9",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.25.9",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.26.6",
         "@babel/plugin-transform-numeric-separator": "^7.25.9",
         "@babel/plugin-transform-object-rest-spread": "^7.25.9",
         "@babel/plugin-transform-object-super": "^7.25.9",
@@ -3122,17 +3108,17 @@
         "@babel/plugin-transform-shorthand-properties": "^7.25.9",
         "@babel/plugin-transform-spread": "^7.25.9",
         "@babel/plugin-transform-sticky-regex": "^7.25.9",
-        "@babel/plugin-transform-template-literals": "^7.25.9",
-        "@babel/plugin-transform-typeof-symbol": "^7.25.9",
+        "@babel/plugin-transform-template-literals": "^7.26.8",
+        "@babel/plugin-transform-typeof-symbol": "^7.26.7",
         "@babel/plugin-transform-unicode-escapes": "^7.25.9",
         "@babel/plugin-transform-unicode-property-regex": "^7.25.9",
         "@babel/plugin-transform-unicode-regex": "^7.25.9",
         "@babel/plugin-transform-unicode-sets-regex": "^7.25.9",
         "@babel/preset-modules": "0.1.6-no-external-plugins",
         "babel-plugin-polyfill-corejs2": "^0.4.10",
-        "babel-plugin-polyfill-corejs3": "^0.10.6",
+        "babel-plugin-polyfill-corejs3": "^0.11.0",
         "babel-plugin-polyfill-regenerator": "^0.6.1",
-        "core-js-compat": "^3.38.1",
+        "core-js-compat": "^3.40.0",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -3140,6 +3126,20 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/babel-plugin-polyfill-corejs3": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.11.1.tgz",
+      "integrity": "sha512-yGCqvBT4rwMczo28xkH/noxJ6MZ4nJfkVYdoDaC/utLtWrXxv27HVrzAeSbqR8SxDsp46n0YF47EbHoixy6rXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.6.3",
+        "core-js-compat": "^3.40.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
     "node_modules/@babel/preset-env/node_modules/semver": {
@@ -3188,9 +3188,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
-      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3201,32 +3201,32 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
-      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.9.tgz",
-      "integrity": "sha512-ZYW7L+pL8ahU5fXmNbPF+iZFHCv5scFak7MZ9bwaRPLUhHh7QQEMjZUg0HevihoqCM5iSYHN61EyCoZvqC+bxg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.0.tgz",
+      "integrity": "sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.9",
-        "@babel/parser": "^7.26.9",
-        "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.9",
+        "@babel/generator": "^7.27.0",
+        "@babel/parser": "^7.27.0",
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -3235,14 +3235,14 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/@babel/generator": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.9.tgz",
-      "integrity": "sha512-kEWdzjOAUMW4hAyrzJ0ZaTOu9OmpyDIQicIh0zg0EEcEkYXZb2TjtBhnHi2ViX7PKwZqF4xwqfAm299/QMP3lg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.0.tgz",
+      "integrity": "sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.26.9",
-        "@babel/types": "^7.26.9",
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -3252,9 +3252,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
-      "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5696,9 +5696,9 @@
       }
     },
     "node_modules/@lmdb/lmdb-darwin-arm64": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-3.2.2.tgz",
-      "integrity": "sha512-WBSJT9Z7DTol5viq+DZD2TapeWOw7mlwXxiSBHgAzqVwsaVb0h/ekMD9iu/jDD8MUA20tO9N0WEdnT06fsUp+g==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-3.2.6.tgz",
+      "integrity": "sha512-yF/ih9EJJZc72psFQbwnn8mExIWfTnzWJg+N02hnpXtDPETYLmQswIMBn7+V88lfCaFrMozJsUvcEQIkEPU0Gg==",
       "cpu": [
         "arm64"
       ],
@@ -5710,9 +5710,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-darwin-x64": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-3.2.2.tgz",
-      "integrity": "sha512-4S13kUtR7c/j/MzkTIBJCXv52hQ41LG2ukeaqw4Eng9K0pNKLFjo1sDSz96/yKhwykxrWDb13ddJ/ZqD3rAhUA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-3.2.6.tgz",
+      "integrity": "sha512-5BbCumsFLbCi586Bb1lTWQFkekdQUw8/t8cy++Uq251cl3hbDIGEwD9HAwh8H6IS2F6QA9KdKmO136LmipRNkg==",
       "cpu": [
         "x64"
       ],
@@ -5724,9 +5724,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-linux-arm": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-3.2.2.tgz",
-      "integrity": "sha512-uW31JmfuPAaLUYW7NsEU8gzwgDAzpGPwjvkxnKlcWd8iDutoPKDJi8Wk9lFmPEZRxVSB0j1/wDQ7N2qliR9UFA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-3.2.6.tgz",
+      "integrity": "sha512-+6XgLpMb7HBoWxXj+bLbiiB4s0mRRcDPElnRS3LpWRzdYSe+gFk5MT/4RrVNqd2MESUDmb53NUXw1+BP69bjiQ==",
       "cpu": [
         "arm"
       ],
@@ -5738,9 +5738,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-linux-arm64": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-3.2.2.tgz",
-      "integrity": "sha512-4hdgZtWI1idQlWRp+eleWXD9KLvObgboRaVoBj2POdPEYvsKANllvMW0El8tEQwtw74yB9NT6P8ENBB5UJf5+g==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-3.2.6.tgz",
+      "integrity": "sha512-l5VmJamJ3nyMmeD1ANBQCQqy7do1ESaJQfKPSm2IG9/ADZryptTyCj8N6QaYgIWewqNUrcbdMkJajRQAt5Qjfg==",
       "cpu": [
         "arm64"
       ],
@@ -5752,9 +5752,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-linux-x64": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-3.2.2.tgz",
-      "integrity": "sha512-A0zjf4a2vM4B4GAx78ncuOTZ8Ka1DbTaG1Axf1e00Sa7f5coqlWiLg1PX7Gxvyibc2YqtqB+8tg1KKrE8guZVw==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-3.2.6.tgz",
+      "integrity": "sha512-nDYT8qN9si5+onHYYaI4DiauDMx24OAiuZAUsEqrDy+ja/3EbpXPX/VAkMV8AEaQhy3xc4dRC+KcYIvOFefJ4Q==",
       "cpu": [
         "x64"
       ],
@@ -5766,9 +5766,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-win32-x64": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-3.2.2.tgz",
-      "integrity": "sha512-Y0qoSCAja+xZE7QQ0LCHoYAuyI1n9ZqukQJa8lv9X3yCvWahFF7OYHAgVH1ejp43XWstj3U89/PAAzcowgF/uQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-3.2.6.tgz",
+      "integrity": "sha512-XlqVtILonQnG+9fH2N3Aytria7P/1fwDgDhl29rde96uH2sLB8CHORIf2PfuLVzFQJ7Uqp8py9AYwr3ZUCFfWg==",
       "cpu": [
         "x64"
       ],
@@ -6699,9 +6699,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "19.1.9",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-19.1.9.tgz",
-      "integrity": "sha512-mGxFhyYHJoI1GX58zpIl0TnJqyTi8uHhZHS3F20MZGD+RSpKvdfLFI7k2FVnEEbg48nGSLgflEdYj+fx13Xswg==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-19.2.5.tgz",
+      "integrity": "sha512-rp9hRFJiUzRrlUBbM3c4BSt/zB93GLM1X9eb+JQOwBsoQhRL92VU9kkffGDpK14hf6uB4goQ00AvQ4lEnxlUag==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6710,8 +6710,8 @@
         "yarn": ">= 1.13.0"
       },
       "peerDependencies": {
-        "@angular/compiler-cli": "^19.0.0",
-        "typescript": ">=5.5 <5.8",
+        "@angular/compiler-cli": "^19.0.0 || ^19.2.0-next.0",
+        "typescript": ">=5.5 <5.9",
         "webpack": "^5.54.0"
       }
     },
@@ -13674,9 +13674,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.1.tgz",
-      "integrity": "sha512-NN+fvwH/kV01dYUQ3PTOZns4LWtWhOFCAhQ/pHb88WQ1hNe5V/dvFwc4VJcDL11LT9xSX0QtsR8sWUuyOuOq7g==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17740,9 +17740,9 @@
       }
     },
     "node_modules/esbuild-wasm": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/esbuild-wasm/-/esbuild-wasm-0.24.2.tgz",
-      "integrity": "sha512-03/7Z1gD+ohDnScFztvI4XddTAbKVmMEzCvvkBpQdWKEXJ+73dTyeNrmdxP1Q0zpDMFjzUJwtK4rLjqwiHbzkw==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/esbuild-wasm/-/esbuild-wasm-0.25.1.tgz",
+      "integrity": "sha512-dZxPeDHcDIQ6ilml/NzYxnPbNkoVsHSFH3JGLSobttc5qYYgExMo8lh2XcB+w+AfiqykVDGK5PWanGB0gWaAWw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -23373,9 +23373,9 @@
       }
     },
     "node_modules/less": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/less/-/less-4.2.1.tgz",
-      "integrity": "sha512-CasaJidTIhWmjcqv0Uj5vccMI7pJgfD9lMkKtlnTHAdJdYK/7l8pM9tumLyJ0zhbD4KJLo/YvTj+xznQd5NBhg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/less/-/less-4.2.2.tgz",
+      "integrity": "sha512-tkuLHQlvWUTeQ3doAqnHbNn8T6WX1KA8yvbKG9x4VtKtIjHsVKQZCH11zRgAfbDAXC2UNIg/K9BYAAcEzUIrNg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -23650,9 +23650,9 @@
       }
     },
     "node_modules/lmdb": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-3.2.2.tgz",
-      "integrity": "sha512-LriG93la4PbmPMwI7Hbv8W+0ncLK7549w4sbZSi4QGDjnnxnmNMgxUkaQTEMzH8TpwsfFvgEjpLX7V8B/I9e3g==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-3.2.6.tgz",
+      "integrity": "sha512-SuHqzPl7mYStna8WRotY8XX/EUZBjjv3QyKIByeCLFfC9uXT/OIHByEcA07PzbMfQAM0KYJtLgtpMRlIe5dErQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -23668,12 +23668,12 @@
         "download-lmdb-prebuilds": "bin/download-prebuilds.js"
       },
       "optionalDependencies": {
-        "@lmdb/lmdb-darwin-arm64": "3.2.2",
-        "@lmdb/lmdb-darwin-x64": "3.2.2",
-        "@lmdb/lmdb-linux-arm": "3.2.2",
-        "@lmdb/lmdb-linux-arm64": "3.2.2",
-        "@lmdb/lmdb-linux-x64": "3.2.2",
-        "@lmdb/lmdb-win32-x64": "3.2.2"
+        "@lmdb/lmdb-darwin-arm64": "3.2.6",
+        "@lmdb/lmdb-darwin-x64": "3.2.6",
+        "@lmdb/lmdb-linux-arm": "3.2.6",
+        "@lmdb/lmdb-linux-arm64": "3.2.6",
+        "@lmdb/lmdb-linux-x64": "3.2.6",
+        "@lmdb/lmdb-win32-x64": "3.2.6"
       }
     },
     "node_modules/lmdb/node_modules/node-addon-api": {
@@ -24906,9 +24906,9 @@
       }
     },
     "node_modules/mrmime": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.0.tgz",
-      "integrity": "sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -31197,9 +31197,9 @@
       }
     },
     "node_modules/prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -32391,9 +32391,9 @@
       "license": "MIT"
     },
     "node_modules/sass": {
-      "version": "1.83.1",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.83.1.tgz",
-      "integrity": "sha512-EVJbDaEs4Rr3F0glJzFSOvtg2/oy2V/YrGFPqPY24UqcLDWcI9ZY5sN+qyO3c/QCZwzgfirvhXvINiJCE/OLcA==",
+      "version": "1.85.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.85.0.tgz",
+      "integrity": "sha512-3ToiC1xZ1Y8aU7+CkgCI/tqyuPXEmYGJXO7H4uqp0xkLXUqp88rQQ4j1HmP37xSJLbCJPaIiv+cT1y+grssrww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -32412,9 +32412,9 @@
       }
     },
     "node_modules/sass-loader": {
-      "version": "16.0.4",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.4.tgz",
-      "integrity": "sha512-LavLbgbBGUt3wCiYzhuLLu65+fWXaXLmq7YxivLhEqmiupCFZ5sKUAipK3do6V80YSU0jvSxNhEdT13IXNr3rg==",
+      "version": "16.0.5",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.5.tgz",
+      "integrity": "sha512-oL+CMBXrj6BZ/zOq4os+UECPL+bWqt6OAC6DWS8Ln8GZRcMDjlJ4JC3FBDuHJdYaFWIdKNIBYmtZtK2MaMkNIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -34881,9 +34881,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.37.0.tgz",
-      "integrity": "sha512-B8wRRkmre4ERucLM/uXx4MOV5cbnOlVAqUst+1+iLKPI0dOgFO28f84ptoQt9HEI537PMzfYa/d+GEPKTRXmYA==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
+      "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -36074,12 +36074,11 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.0.tgz",
-      "integrity": "sha512-7dPxoo+WsT/64rDcwoOjk76XHj+TqNTIvHKcuMQ1k4/SeHDaQt5GFAeLYzrimZrMpn/O6DtdI03WUjdxuPM0oQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
+      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "postcss": "^8.5.3",
@@ -36352,9 +36351,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.97.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
-      "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
+      "version": "5.98.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.98.0.tgz",
+      "integrity": "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -36376,9 +36375,9 @@
         "loader-runner": "^4.2.0",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
+        "schema-utils": "^4.3.0",
         "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.10",
+        "terser-webpack-plugin": "^5.3.11",
         "watchpack": "^2.4.1",
         "webpack-sources": "^3.2.3"
       },
@@ -36693,33 +36692,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/webpack/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/webpack/node_modules/ajv-keywords": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": "^6.9.1"
-      }
-    },
     "node_modules/webpack/node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -36750,32 +36722,6 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/webpack/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/webpack/node_modules/schema-utils": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
     },
     "node_modules/websocket-driver": {
       "version": "0.7.4",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "zone.js": "^0.15.0"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "~19.1.0",
+    "@angular-devkit/build-angular": "~19.2.5",
     "@angular-devkit/core": "~19.1.0",
     "@angular-devkit/schematics": "~19.1.0",
     "@angular/cli": "~19.1.0",


### PR DESCRIPTION
This upgrade resolves security vulnerabilities flagged by `npm audit`. No production code is affected.