### PR TITLE
feat(drawercomponent): add drawercomponent feature

### DIFF
--- a/libs/ngx-tailwind-flex-ui/documentation.json
+++ b/libs/ngx-tailwind-flex-ui/documentation.json
@@ -665,7 +665,7 @@
             "assetsDirs": [],
             "styleUrlsData": [
                 {
-                    "data": "@import url('https://fonts.googleapis.com/icon?family=Material+Icons');\r\n\r\n@import 'tailwindcss/base';\r\n@import 'tailwindcss/components';\r\n@import 'tailwindcss/utilities';\r\n\r\n.material-icons {\r\n  font-family: 'Material Icons';\r\n  font-size: 18px; /* Matches text-lg in Tailwind */\r\n  font-weight: normal;\r\n  font-style: normal;\r\n  display: inline-block;\r\n  line-height: 1;\r\n  text-transform: none;\r\n  letter-spacing: normal;\r\n  word-wrap: normal;\r\n  white-space: nowrap;\r\n  direction: ltr;\r\n}\r\n\r\n.message {\r\n  max-width: 300px; /* Adjust as needed */\r\n  white-space: nowrap;\r\n  overflow: hidden;\r\n  text-overflow: ellipsis;\r\n}\r\n\r\n.material-icons--custom-color {\r\n  color: inherit !important;\r\n}\r\n",
+                    "data": "@import url('https://fonts.googleapis.com/icon?family=Material+Icons');\r\n\r\n.material-icons {\r\n  font-family: 'Material Icons';\r\n  font-size: 18px; /* Matches text-lg in Tailwind */\r\n  font-weight: normal;\r\n  font-style: normal;\r\n  display: inline-block;\r\n  line-height: 1;\r\n  text-transform: none;\r\n  letter-spacing: normal;\r\n  word-wrap: normal;\r\n  white-space: nowrap;\r\n  direction: ltr;\r\n}\r\n\r\n.message {\r\n  max-width: 300px; /* Adjust as needed */\r\n  white-space: nowrap;\r\n  overflow: hidden;\r\n  text-overflow: ellipsis;\r\n}\r\n\r\n.material-icons--custom-color {\r\n  color: inherit !important;\r\n}\r\n",
                     "styleUrl": "./alert.component.css"
                 }
             ],
@@ -860,7 +860,7 @@
         },
         {
             "name": "ButtonComponent",
-            "id": "component-ButtonComponent-4a0e060db7ffd16a679766d8091dfca8a2ed6c08cda8975d4756d1434716949e4060c639031b77f2ca38977983acb0622a2fa77db817a21a979f35ebeca9f233",
+            "id": "component-ButtonComponent-7b549b2939b9a34abd922e3a0255997fdcdc44e13e0d3149f6f081fd94e8328dfcef16d4b504efc25d22156e814a32fd37682ce25460fb63fbe9f89259f6c17c",
             "file": "libs/ngx-tailwind-flex-ui/src/lib/button/button.component.ts",
             "encapsulation": [],
             "entryComponents": [],
@@ -925,7 +925,7 @@
             "description": "",
             "rawdescription": "\n",
             "type": "component",
-            "sourceCode": "import { Component, Input, HostBinding } from '@angular/core';\r\n\r\n@Component({\r\n  selector: 'lib-button',\r\n  standalone: true,\r\n  templateUrl: './button.component.html',\r\n  styles: [], // No inline styles; Tailwind handles it\r\n})\r\nexport class ButtonComponent {\r\n  @Input() variant: 'primary' | 'accent' | 'outline' | 'text' = 'primary';\r\n  @Input() disabled = false;\r\n  @Input() class = ''; // Allow users to pass custom Tailwind classes\r\n\r\n  @HostBinding('class') get hostClasses() {\r\n    const baseClasses =\r\n      'inline-flex items-center justify-center px-4 py-2 rounded-md font-medium transition-colors duration-200';\r\n    const variantClasses = {\r\n      primary:\r\n        'bg-blue-600 text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2',\r\n      accent:\r\n        'bg-purple-600 text-white hover:bg-purple-700 focus:ring-2 focus:ring-purple-500 focus:ring-offset-2',\r\n      outline:\r\n        'border border-gray-300 text-gray-700 hover:bg-gray-100 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2',\r\n      text: 'text-gray-700 hover:bg-gray-100 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2',\r\n    };\r\n    const disabledClasses = this.disabled\r\n      ? 'opacity-50 cursor-not-allowed'\r\n      : '';\r\n\r\n    return `${baseClasses} ${variantClasses[this.variant]} ${disabledClasses} ${\r\n      this.class\r\n    }`.trim();\r\n  }\r\n}\r\n",
+            "sourceCode": "import { Component, Input, HostBinding } from '@angular/core';\n\n@Component({\n  selector: 'lib-button',\n  standalone: true,\n  templateUrl: './button.component.html',\n  styles: [], // No inline styles; Tailwind handles it\n})\nexport class ButtonComponent {\n  @Input() variant: 'primary' | 'accent' | 'outline' | 'text' = 'primary';\n  @Input() disabled = false;\n  @Input() class = ''; // Allow users to pass custom Tailwind classes\n\n  @HostBinding('class') get hostClasses() {\n    const baseClasses =\n      'inline-flex items-center justify-center px-4 py-2 rounded-md font-medium transition-colors duration-200';\n    const variantClasses = {\n      primary:\n        'bg-blue-600 text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2',\n      accent:\n        'bg-purple-600 text-white hover:bg-purple-700 focus:ring-2 focus:ring-purple-500 focus:ring-offset-2',\n      outline:\n        'border border-gray-300 text-gray-700 hover:bg-gray-100 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2',\n      text: 'text-gray-700 hover:bg-gray-100 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2',\n    };\n    const disabledClasses = this.disabled\n      ? 'opacity-50 cursor-not-allowed'\n      : '';\n\n    return `${baseClasses} ${variantClasses[this.variant]} ${disabledClasses} ${\n      this.class\n    }`.trim();\n  }\n}\n",
             "assetsDirs": [],
             "styleUrlsData": "",
             "stylesData": "",
@@ -941,11 +941,335 @@
                     }
                 }
             },
-            "templateData": "<button [disabled]=\"disabled\">\r\n  <ng-content></ng-content>\r\n</button>\r\n"
+            "templateData": "<button [disabled]=\"disabled\">\n  <ng-content></ng-content>\n</button>\n"
+        },
+        {
+            "name": "DrawerComponent",
+            "id": "component-DrawerComponent-bb732ac0b9a10c30eba1685ab98ef48d5b9d7af3a50960faeeea683235ed313692737bba01e160da820fb2a3ab0e3697f4e2962b87b77f84d5b64a7374351122",
+            "file": "libs/ngx-tailwind-flex-ui/src/lib/drawer/drawer.component.ts",
+            "changeDetection": "ChangeDetectionStrategy.OnPush",
+            "encapsulation": [],
+            "entryComponents": [],
+            "inputs": [],
+            "outputs": [],
+            "providers": [],
+            "selector": "lib-drawer",
+            "styleUrls": [
+                "./drawer.component.css"
+            ],
+            "styles": [],
+            "templateUrl": [
+                "./drawer.component.html"
+            ],
+            "viewProviders": [],
+            "hostDirectives": [],
+            "inputsClass": [
+                {
+                    "name": "mode",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 24,
+                    "type": "\"persistent\" | \"temporary\" | \"mini\"",
+                    "decorators": []
+                },
+                {
+                    "name": "open",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 36,
+                    "type": "boolean",
+                    "decorators": []
+                },
+                {
+                    "name": "position",
+                    "defaultValue": "'left'",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 22,
+                    "type": "\"left\" | \"right\"",
+                    "decorators": []
+                }
+            ],
+            "outputsClass": [
+                {
+                    "name": "openChange",
+                    "defaultValue": "new EventEmitter<boolean>()",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 47,
+                    "type": "EventEmitter"
+                }
+            ],
+            "propertiesClass": [
+                {
+                    "name": "_mode",
+                    "defaultValue": "'temporary'",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "\"persistent\" | \"temporary\" | \"mini\"",
+                    "indexKey": "",
+                    "optional": false,
+                    "description": "",
+                    "line": 31,
+                    "modifierKind": [
+                        123
+                    ]
+                },
+                {
+                    "name": "_open",
+                    "defaultValue": "false",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "indexKey": "",
+                    "optional": false,
+                    "description": "",
+                    "line": 33,
+                    "modifierKind": [
+                        123
+                    ]
+                }
+            ],
+            "methodsClass": [
+                {
+                    "name": "close",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 70,
+                    "deprecated": false,
+                    "deprecationMessage": ""
+                },
+                {
+                    "name": "getTranslationClass",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "string",
+                    "typeParameters": [],
+                    "line": 95,
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "modifierKind": [
+                        123
+                    ]
+                },
+                {
+                    "name": "onEscape",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 60,
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "decorators": [
+                        {
+                            "name": "HostListener",
+                            "stringifiedArguments": "'document:keydown.escape', ['$event']"
+                        }
+                    ],
+                    "modifierKind": [
+                        170
+                    ]
+                },
+                {
+                    "name": "openDrawer",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 74,
+                    "deprecated": false,
+                    "deprecationMessage": ""
+                },
+                {
+                    "name": "toggle",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 66,
+                    "deprecated": false,
+                    "deprecationMessage": ""
+                }
+            ],
+            "deprecated": false,
+            "deprecationMessage": "",
+            "hostBindings": [
+                {
+                    "name": "class",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 79,
+                    "type": "string",
+                    "decorators": []
+                }
+            ],
+            "hostListeners": [
+                {
+                    "name": "document:keydown.escape",
+                    "args": [],
+                    "argsDecorator": [
+                        "$event"
+                    ],
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 60
+                }
+            ],
+            "standalone": true,
+            "imports": [
+                {
+                    "name": "CommonModule",
+                    "type": "module"
+                }
+            ],
+            "description": "",
+            "rawdescription": "\n",
+            "type": "component",
+            "sourceCode": "import {\n  Component,\n  Input,\n  Output,\n  EventEmitter,\n  HostListener,\n  ChangeDetectionStrategy,\n  HostBinding,\n  ChangeDetectorRef,\n} from '@angular/core';\nimport { CommonModule } from '@angular/common';\n\n@Component({\n  selector: 'lib-drawer',\n  templateUrl: './drawer.component.html',\n  styleUrls: ['./drawer.component.css'],\n  changeDetection: ChangeDetectionStrategy.OnPush,\n  standalone: true,\n  imports: [CommonModule],\n})\nexport class DrawerComponent {\n  @Input() position: 'left' | 'right' = 'left';\n  @Input()\n  set mode(value: 'persistent' | 'temporary' | 'mini') {\n    this._mode = value;\n    this.cdr.markForCheck(); // Trigger change detection\n  }\n  get mode(): 'persistent' | 'temporary' | 'mini' {\n    return this._mode;\n  }\n  private _mode: 'persistent' | 'temporary' | 'mini' = 'temporary';\n\n  private _open = false;\n\n  @Input()\n  get open(): boolean {\n    return this._open;\n  }\n  set open(value: boolean) {\n    if (this._open !== value) {\n      this._open = value;\n      this.openChange.emit(this._open);\n      this.cdr.markForCheck(); // Trigger change detection\n    }\n  }\n\n  @Output() openChange = new EventEmitter<boolean>();\n\n  constructor(private cdr: ChangeDetectorRef) {}\n\n  get isClosable(): boolean {\n    return this._mode === 'temporary';\n  }\n\n  get backdrop(): boolean {\n    return this._mode === 'temporary' && this._open;\n  }\n\n  @HostListener('document:keydown.escape', ['$event'])\n  onEscape() {\n    if (this.isClosable) {\n      this.close();\n    }\n  }\n\n  toggle(): void {\n    this.open = !this._open;\n  }\n\n  close(): void {\n    this.open = false;\n  }\n\n  openDrawer(): void {\n    this.open = true;\n  }\n\n  @HostBinding('class')\n  get drawerClasses(): string {\n    return [\n      'fixed',\n      'top-0',\n      this.position === 'left' ? 'left-0' : 'right-0',\n      this.getTranslationClass(),\n      this._mode === 'mini' ? 'w-16' : 'w-64',\n      'h-full',\n      'bg-white',\n      'z-40',\n      'transition-transform',\n      'duration-300',\n      'shadow-lg',\n    ].join(' ');\n  }\n\n  private getTranslationClass(): string {\n    if (this._open) return 'translate-x-0';\n    return this.position === 'left' ? '-translate-x-full' : 'translate-x-full';\n  }\n}",
+            "assetsDirs": [],
+            "styleUrlsData": [
+                {
+                    "data": ":host {\r\n    display: block;\r\n    color: rgb(129, 126, 133);\r\n  }\r\n  \r\n  .drawer-content {\r\n    width: 100%;\r\n    height: 100%;\r\n    position: relative;\r\n  }\r\n  \r\n  .opacity-50 {\r\n    background-color: rgba(180, 28, 28, 0.5);\r\n  }",
+                    "styleUrl": "./drawer.component.css"
+                }
+            ],
+            "stylesData": "",
+            "constructorObj": {
+                "name": "constructor",
+                "description": "",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "args": [
+                    {
+                        "name": "cdr",
+                        "type": "ChangeDetectorRef",
+                        "deprecated": false,
+                        "deprecationMessage": ""
+                    }
+                ],
+                "line": 47,
+                "jsdoctags": [
+                    {
+                        "name": "cdr",
+                        "type": "ChangeDetectorRef",
+                        "deprecated": false,
+                        "deprecationMessage": "",
+                        "tagName": {
+                            "text": "param"
+                        }
+                    }
+                ]
+            },
+            "extends": [],
+            "accessors": {
+                "mode": {
+                    "name": "mode",
+                    "setSignature": {
+                        "name": "mode",
+                        "type": "void",
+                        "deprecated": false,
+                        "deprecationMessage": "",
+                        "args": [
+                            {
+                                "name": "value",
+                                "type": "\"persistent\" | \"temporary\" | \"mini\"",
+                                "deprecated": false,
+                                "deprecationMessage": ""
+                            }
+                        ],
+                        "returnType": "void",
+                        "line": 24,
+                        "jsdoctags": [
+                            {
+                                "name": "value",
+                                "type": "\"persistent\" | \"temporary\" | \"mini\"",
+                                "deprecated": false,
+                                "deprecationMessage": "",
+                                "tagName": {
+                                    "text": "param"
+                                }
+                            }
+                        ]
+                    },
+                    "getSignature": {
+                        "name": "mode",
+                        "type": "",
+                        "returnType": "\"persistent\" | \"temporary\" | \"mini\"",
+                        "line": 28
+                    }
+                },
+                "open": {
+                    "name": "open",
+                    "setSignature": {
+                        "name": "open",
+                        "type": "void",
+                        "deprecated": false,
+                        "deprecationMessage": "",
+                        "args": [
+                            {
+                                "name": "value",
+                                "type": "boolean",
+                                "deprecated": false,
+                                "deprecationMessage": ""
+                            }
+                        ],
+                        "returnType": "void",
+                        "line": 39,
+                        "jsdoctags": [
+                            {
+                                "name": "value",
+                                "type": "boolean",
+                                "deprecated": false,
+                                "deprecationMessage": "",
+                                "tagName": {
+                                    "text": "param"
+                                }
+                            }
+                        ]
+                    },
+                    "getSignature": {
+                        "name": "open",
+                        "type": "boolean",
+                        "returnType": "boolean",
+                        "line": 36
+                    }
+                },
+                "isClosable": {
+                    "name": "isClosable",
+                    "getSignature": {
+                        "name": "isClosable",
+                        "type": "boolean",
+                        "returnType": "boolean",
+                        "line": 51
+                    }
+                },
+                "backdrop": {
+                    "name": "backdrop",
+                    "getSignature": {
+                        "name": "backdrop",
+                        "type": "boolean",
+                        "returnType": "boolean",
+                        "line": 55
+                    }
+                },
+                "drawerClasses": {
+                    "name": "drawerClasses",
+                    "getSignature": {
+                        "name": "drawerClasses",
+                        "type": "string",
+                        "returnType": "string",
+                        "line": 79
+                    }
+                }
+            },
+            "templateData": "<!-- Drawer Container -->\n<div\n  [class]=\"drawerClasses\"\n  [class.hidden]=\"!open\"\n  role=\"dialog\"\n  aria-labelledby=\"drawer-title\"\n  [attr.aria-hidden]=\"!open\"\n>\n  <!-- Drawer Content -->\n  <div class=\"relative flex flex-col h-full bg-white shadow-xl p-4\">\n    <!-- Close Button -->\n    <button\n      *ngIf=\"isClosable\"\n      class=\"absolute top-4 right-4 text-gray-600 hover:text-gray-800\"\n      (click)=\"close()\"\n      aria-label=\"Close Drawer\"\n    >\n      <svg\n        xmlns=\"http://www.w3.org/2000/svg\"\n        class=\"h-6 w-6\"\n        viewBox=\"0 0 20 20\"\n        fill=\"currentColor\"\n        aria-hidden=\"true\"\n      >\n        <path\n          fill-rule=\"evenodd\"\n          d=\"M10 9.293l5.147-5.146a1 1 0 111.414 1.414L11.414 10l5.147 5.146a1 1 0 11-1.414 1.414L10 11.414l-5.146 5.147a1 1 0 11-1.414-1.414L8.586 10 3.439 4.854a1 1 0 111.414-1.414L10 9.293z\"\n          clip-rule=\"evenodd\"\n        />\n      </svg>\n    </button>\n\n    <!-- Custom Content -->\n    <ng-content></ng-content>\n  </div>\n</div>\n\n<!-- Backdrop Overlay -->\n<div\n  *ngIf=\"backdrop\"\n  class=\"fixed inset-0 bg-black bg-opacity-50 z-30\"\n  (click)=\"close()\"\n  [attr.aria-hidden]=\"true\"\n  role=\"button\"\n  tabindex=\"0\"\n></div>"
         },
         {
             "name": "IconComponent",
-            "id": "component-IconComponent-f8319707c4db8c28b1c60cee96154c58150cc29b3cf08e5d353aea2d6c0988772ae60eaf015395a6d4d3e8fb7cf4bea0e18774b39cae83d9e473d3a30a4a0fe0",
+            "id": "component-IconComponent-f4ffddc67d4dc8cdcc909de572d3660df47682439e6a9f4405942573613c1afc2dac2183ba5b0f69bbb0568ec3eb59ac6e3bfa8c56f5eecf072b8b573f060f08",
             "file": "libs/ngx-tailwind-flex-ui/src/lib/icon/icon.component.ts",
             "encapsulation": [],
             "entryComponents": [],
@@ -1008,11 +1332,11 @@
             "description": "",
             "rawdescription": "\n",
             "type": "component",
-            "sourceCode": "import { Component, Input } from '@angular/core';\r\nimport { CommonModule } from '@angular/common';\r\n\r\n@Component({\r\n  selector: 'lib-icon',\r\n  standalone: true,\r\n  imports: [CommonModule],\r\n  templateUrl: './icon.component.html',\r\n  styleUrls: ['./icon.component.css'],\r\n})\r\nexport class IconComponent {\r\n  @Input() name = 'home';\r\n  @Input() size: 'sm' | 'md' | 'lg' | 'xl' = 'md';\r\n  @Input() color = 'text-gray-500';\r\n\r\n  get sizePx(): number {\r\n    const sizeMap: Record<string, number> = {\r\n      sm: 16,\r\n      md: 24,  // Default Material Icon size\r\n      lg: 32,\r\n      xl: 48,\r\n    };\r\n    return sizeMap[this.size] || sizeMap['md'];\r\n  }\r\n\r\n  get colorClass(): string {\r\n    return this.color;\r\n  }\r\n}\r\n",
+            "sourceCode": "import { Component, Input } from '@angular/core';\nimport { CommonModule } from '@angular/common';\n\n@Component({\n  selector: 'lib-icon',\n  standalone: true,\n  imports: [CommonModule],\n  templateUrl: './icon.component.html',\n  styleUrls: ['./icon.component.css'],\n})\nexport class IconComponent {\n  @Input() name = 'home';\n  @Input() size: 'sm' | 'md' | 'lg' | 'xl' = 'md';\n  @Input() color = 'text-gray-500';\n\n  get sizePx(): number {\n    const sizeMap: Record<string, number> = {\n      sm: 16,\n      md: 24,  // Default Material Icon size\n      lg: 32,\n      xl: 48,\n    };\n    return sizeMap[this.size] || sizeMap['md'];\n  }\n\n  get colorClass(): string {\n    return this.color;\n  }\n}\n",
             "assetsDirs": [],
             "styleUrlsData": [
                 {
-                    "data": ".material-icons {\r\n    display: inline-flex;\r\n    align-items: center;\r\n    justify-content: center;\r\n    vertical-align: middle;\r\n}",
+                    "data": ".material-icons {\n    display: inline-flex;\n    align-items: center;\n    justify-content: center;\n    vertical-align: middle;\n}",
                     "styleUrl": "./icon.component.css"
                 }
             ],
@@ -1038,11 +1362,11 @@
                     }
                 }
             },
-            "templateData": "<span \r\n  class=\"material-icons\"\r\n  [ngClass]=\"colorClass\"\r\n  [style.font-size.px]=\"sizePx\">\r\n  {{ name }}\r\n</span>\r\n"
+            "templateData": "<span \n  class=\"material-icons\"\n  [ngClass]=\"colorClass\"\n  [style.font-size.px]=\"sizePx\">\n  {{ name }}\n</span>\n"
         },
         {
             "name": "LoadingSpinnerComponent",
-            "id": "component-LoadingSpinnerComponent-87646e3e0b77bb88f2ed95a1c78b1b56876072354a4b59a95947194859bc52044d1abe3d30b75bb063d39e64c4a3b386c488745ad2424f51f0603f821834f0ca",
+            "id": "component-LoadingSpinnerComponent-10509c463c4902342a644ec0f29cb262b6513479ebdd929cfacec37856de1d1ef4beb814f63ac3f69346f425e71fbf1fbe354f8313e1b711ac3f038fe8fd695d",
             "file": "libs/ngx-tailwind-flex-ui/src/lib/loadingSpinner/loadingSpinner.component.ts",
             "encapsulation": [],
             "entryComponents": [],
@@ -1123,21 +1447,21 @@
             "description": "",
             "rawdescription": "\n",
             "type": "component",
-            "sourceCode": "import { Component, Input } from '@angular/core';\r\nimport { CommonModule } from '@angular/common';\r\n\r\n@Component({\r\n  selector: 'lib-loading-spinner',\r\n  standalone: true,\r\n  imports: [CommonModule],\r\n  templateUrl: './loadingSpinner.component.html',\r\n  styleUrls: ['./loadingSpinner.component.css'],\r\n})\r\nexport class LoadingSpinnerComponent {\r\n  @Input() mode: 'determinate' | 'indeterminate' = 'indeterminate'; // Loading state\r\n  @Input() value = 0; // Progress value (0-100) for determinate mode\r\n  @Input() size = 40; // Diameter in pixels\r\n  @Input() thickness = 4; // Stroke width in pixels\r\n  @Input() color = '#3b82f6'; // Default Tailwind blue-500\r\n}\r\n",
+            "sourceCode": "import { Component, Input } from '@angular/core';\nimport { CommonModule } from '@angular/common';\n\n@Component({\n  selector: 'lib-loading-spinner',\n  standalone: true,\n  imports: [CommonModule],\n  templateUrl: './loadingSpinner.component.html',\n  styleUrls: ['./loadingSpinner.component.css'],\n})\nexport class LoadingSpinnerComponent {\n  @Input() mode: 'determinate' | 'indeterminate' = 'indeterminate'; // Loading state\n  @Input() value = 0; // Progress value (0-100) for determinate mode\n  @Input() size = 40; // Diameter in pixels\n  @Input() thickness = 4; // Stroke width in pixels\n  @Input() color = '#3b82f6'; // Default Tailwind blue-500\n}\n",
             "assetsDirs": [],
             "styleUrlsData": [
                 {
-                    "data": ":host {\r\n  display: inline-block;\r\n}\r\n\r\nsvg {\r\n  display: block;\r\n}\r\n",
+                    "data": ":host {\n  display: inline-block;\n}\n\nsvg {\n  display: block;\n}\n",
                     "styleUrl": "./loadingSpinner.component.css"
                 }
             ],
             "stylesData": "",
             "extends": [],
-            "templateData": "<div\r\n  class=\"relative inline-block\"\r\n  [style.width.px]=\"size\"\r\n  [style.height.px]=\"size\"\r\n  role=\"progressbar\"\r\n  [attr.aria-valuenow]=\"mode === 'determinate' ? value : null\"\r\n  [attr.aria-valuemin]=\"0\"\r\n  [attr.aria-valuemax]=\"100\"\r\n  [attr.aria-label]=\"mode === 'determinate' ? 'Loading progress' : 'Loading'\"\r\n>\r\n  <!-- Indeterminate Spinner -->\r\n  <svg\r\n    *ngIf=\"mode === 'indeterminate'\"\r\n    class=\"animate-spin\"\r\n    [style.width.px]=\"size\"\r\n    [style.height.px]=\"size\"\r\n    viewBox=\"0 0 100 100\"\r\n    xmlns=\"http://www.w3.org/2000/svg\"\r\n  >\r\n    <circle\r\n      class=\"opacity-25\"\r\n      cx=\"50\"\r\n      cy=\"50\"\r\n      r=\"40\"\r\n      [style.stroke]=\"color\"\r\n      [style.stroke-width]=\"thickness\"\r\n      fill=\"none\"\r\n    />\r\n    <circle\r\n      cx=\"50\"\r\n      cy=\"50\"\r\n      r=\"40\"\r\n      [style.stroke]=\"color\"\r\n      [style.stroke-width]=\"thickness\"\r\n      fill=\"none\"\r\n      stroke-linecap=\"round\"\r\n      stroke-dasharray=\"251.2\"\r\n      stroke-dashoffset=\"62.8\"\r\n    />\r\n  </svg>\r\n\r\n  <!-- Determinate Spinner -->\r\n  <svg\r\n    *ngIf=\"mode === 'determinate'\"\r\n    [style.width.px]=\"size\"\r\n    [style.height.px]=\"size\"\r\n    viewBox=\"0 0 100 100\"\r\n    xmlns=\"http://www.w3.org/2000/svg\"\r\n  >\r\n    <circle\r\n      class=\"opacity-25\"\r\n      cx=\"50\"\r\n      cy=\"50\"\r\n      r=\"40\"\r\n      [style.stroke]=\"color\"\r\n      [style.stroke-width]=\"thickness\"\r\n      fill=\"none\"\r\n    />\r\n    <circle\r\n      class=\"transition-all duration-300 ease-in-out\"\r\n      cx=\"50\"\r\n      cy=\"50\"\r\n      r=\"40\"\r\n      [style.stroke]=\"color\"\r\n      [style.stroke-width]=\"thickness\"\r\n      fill=\"none\"\r\n      stroke-linecap=\"round\"\r\n      [style.stroke-dasharray]=\"251.2\"\r\n      [style.stroke-dashoffset]=\"251.2 - 251.2 * (value / 100)\"\r\n    />\r\n  </svg>\r\n</div>\r\n"
+            "templateData": "<div\n  class=\"relative inline-block\"\n  [style.width.px]=\"size\"\n  [style.height.px]=\"size\"\n  role=\"progressbar\"\n  [attr.aria-valuenow]=\"mode === 'determinate' ? value : null\"\n  [attr.aria-valuemin]=\"0\"\n  [attr.aria-valuemax]=\"100\"\n  [attr.aria-label]=\"mode === 'determinate' ? 'Loading progress' : 'Loading'\"\n>\n  <!-- Indeterminate Spinner -->\n  <svg\n    *ngIf=\"mode === 'indeterminate'\"\n    class=\"animate-spin\"\n    [style.width.px]=\"size\"\n    [style.height.px]=\"size\"\n    viewBox=\"0 0 100 100\"\n    xmlns=\"http://www.w3.org/2000/svg\"\n  >\n    <circle\n      class=\"opacity-25\"\n      cx=\"50\"\n      cy=\"50\"\n      r=\"40\"\n      [style.stroke]=\"color\"\n      [style.stroke-width]=\"thickness\"\n      fill=\"none\"\n    />\n    <circle\n      cx=\"50\"\n      cy=\"50\"\n      r=\"40\"\n      [style.stroke]=\"color\"\n      [style.stroke-width]=\"thickness\"\n      fill=\"none\"\n      stroke-linecap=\"round\"\n      stroke-dasharray=\"251.2\"\n      stroke-dashoffset=\"62.8\"\n    />\n  </svg>\n\n  <!-- Determinate Spinner -->\n  <svg\n    *ngIf=\"mode === 'determinate'\"\n    [style.width.px]=\"size\"\n    [style.height.px]=\"size\"\n    viewBox=\"0 0 100 100\"\n    xmlns=\"http://www.w3.org/2000/svg\"\n  >\n    <circle\n      class=\"opacity-25\"\n      cx=\"50\"\n      cy=\"50\"\n      r=\"40\"\n      [style.stroke]=\"color\"\n      [style.stroke-width]=\"thickness\"\n      fill=\"none\"\n    />\n    <circle\n      class=\"transition-all duration-300 ease-in-out\"\n      cx=\"50\"\n      cy=\"50\"\n      r=\"40\"\n      [style.stroke]=\"color\"\n      [style.stroke-width]=\"thickness\"\n      fill=\"none\"\n      stroke-linecap=\"round\"\n      [style.stroke-dasharray]=\"251.2\"\n      [style.stroke-dashoffset]=\"251.2 - 251.2 * (value / 100)\"\n    />\n  </svg>\n</div>\n"
         },
         {
             "name": "PaginatorComponent",
-            "id": "component-PaginatorComponent-90b8fefde7adb6bec711d3f364730b24718220abba32876ee3d21559d81f12801224e20268295ba5dbd3ab79e2ad599801201dd2d9d9868c944d2902a33c202a",
+            "id": "component-PaginatorComponent-1fb3bb93af7f13625b403ab0e2e05642b5aec29b96c7e71e6542a29cfbd4095e3b2ed2f1be3be82e3ab53ba30d53b56fd48871308a8c9c6149074034d7330bd0",
             "file": "libs/ngx-tailwind-flex-ui/src/lib/paginator/paginator.component.ts",
             "encapsulation": [],
             "entryComponents": [],
@@ -1293,7 +1617,7 @@
             "description": "",
             "rawdescription": "\n",
             "type": "component",
-            "sourceCode": "import { Component, EventEmitter, HostBinding, Input, Output } from '@angular/core';\r\nimport { CommonModule } from '@angular/common';\r\n\r\n@Component({\r\n  selector: 'lib-paginator',\r\n  imports: [CommonModule],\r\n  templateUrl: './paginator.component.html',\r\n})\r\nexport class PaginatorComponent {\r\n  @Input() length = 100; // Total items\r\n  @Input() pageSize = 10; // Items per page\r\n  @Input() pageIndex = 0; // Current page\r\n  @Output() pageChange = new EventEmitter<number>();\r\n  @Output() pageSizeChange = new EventEmitter<number>();\r\n\r\n  pageSizeOptions = [10, 20, 50, 100];\r\n\r\n  @HostBinding('class') get hostClasses() {\r\n    return 'flex justify-between items-center p-4 bg-gray-100 rounded-lg shadow-sm w-full';\r\n  }\r\n\r\n  get totalPages(): number {\r\n    return Math.ceil(this.length / this.pageSize);\r\n  }\r\n\r\n  get isFirstPage(): boolean {\r\n    return this.pageIndex === 0;\r\n  }\r\n\r\n  get isLastPage(): boolean {\r\n    return this.pageIndex === this.totalPages - 1;\r\n  }\r\n\r\n  get startItem(): number {\r\n    return this.pageIndex * this.pageSize + 1;\r\n  }\r\n\r\n  get endItem(): number {\r\n    return Math.min((this.pageIndex + 1) * this.pageSize, this.length);\r\n  }\r\n\r\n  changePage(newIndex: number) {\r\n    if (newIndex >= 0 && newIndex < this.totalPages) {\r\n      this.pageIndex = newIndex;\r\n      this.pageChange.emit(this.pageIndex);\r\n    }\r\n  }\r\n\r\n  changePageSize(event: Event) {\r\n    const newSize = Number((event.target as HTMLSelectElement).value);\r\n    this.pageSize = newSize;\r\n    this.pageIndex = 0; // Reset to first page\r\n    this.pageSizeChange.emit(this.pageSize);\r\n    this.pageChange.emit(this.pageIndex);\r\n  }\r\n}\r\n",
+            "sourceCode": "import { Component, EventEmitter, HostBinding, Input, Output } from '@angular/core';\nimport { CommonModule } from '@angular/common';\n\n@Component({\n  selector: 'lib-paginator',\n  imports: [CommonModule],\n  templateUrl: './paginator.component.html',\n})\nexport class PaginatorComponent {\n  @Input() length = 100; // Total items\n  @Input() pageSize = 10; // Items per page\n  @Input() pageIndex = 0; // Current page\n  @Output() pageChange = new EventEmitter<number>();\n  @Output() pageSizeChange = new EventEmitter<number>();\n\n  pageSizeOptions = [10, 20, 50, 100];\n\n  @HostBinding('class') get hostClasses() {\n    return 'flex justify-between items-center p-4 bg-gray-100 rounded-lg shadow-sm w-full';\n  }\n\n  get totalPages(): number {\n    return Math.ceil(this.length / this.pageSize);\n  }\n\n  get isFirstPage(): boolean {\n    return this.pageIndex === 0;\n  }\n\n  get isLastPage(): boolean {\n    return this.pageIndex === this.totalPages - 1;\n  }\n\n  get startItem(): number {\n    return this.pageIndex * this.pageSize + 1;\n  }\n\n  get endItem(): number {\n    return Math.min((this.pageIndex + 1) * this.pageSize, this.length);\n  }\n\n  changePage(newIndex: number) {\n    if (newIndex >= 0 && newIndex < this.totalPages) {\n      this.pageIndex = newIndex;\n      this.pageChange.emit(this.pageIndex);\n    }\n  }\n\n  changePageSize(event: Event) {\n    const newSize = Number((event.target as HTMLSelectElement).value);\n    this.pageSize = newSize;\n    this.pageIndex = 0; // Reset to first page\n    this.pageSizeChange.emit(this.pageSize);\n    this.pageChange.emit(this.pageIndex);\n  }\n}\n",
             "assetsDirs": [],
             "styleUrlsData": "",
             "stylesData": "",
@@ -1354,11 +1678,11 @@
                     }
                 }
             },
-            "templateData": "<!-- Page Size Selector -->\r\n<div class=\"flex items-center space-x-2\">\r\n  <label for=\"pageSizeSelect\" class=\"text-gray-600 text-sm\">Items per page:</label>\r\n  <select \r\n    id=\"pageSizeSelect\"\r\n    [value]=\"pageSize\"\r\n    (change)=\"changePageSize($event)\"\r\n    class=\"border border-gray-300 rounded-md px-2 py-2 bg-white text-gray-700\">\r\n    <option *ngFor=\"let size of pageSizeOptions\" [value]=\"size\">{{ size }}</option>\r\n  </select>\r\n</div>\r\n\r\n<!-- Page Information -->\r\n<span class=\"text-gray-500 text-sm\">\r\n  {{ startItem }} – {{ endItem }} of {{ length }}\r\n</span>\r\n\r\n<!-- Navigation Controls -->\r\n<button \r\n  [disabled]=\"isFirstPage\"\r\n  (click)=\"changePage(pageIndex - 1)\"\r\n  class=\"p-2 text-gray-500 hover:text-black disabled:opacity-50\">\r\n  ❮\r\n</button>\r\n\r\n<button \r\n  [disabled]=\"isLastPage\"\r\n  (click)=\"changePage(pageIndex + 1)\"\r\n  class=\"p-2 text-gray-500 hover:text-black disabled:opacity-50\">\r\n  ❯\r\n</button>\r\n"
+            "templateData": "<!-- Page Size Selector -->\n<div class=\"flex items-center space-x-2\">\n  <label for=\"pageSizeSelect\" class=\"text-gray-600 text-sm\">Items per page:</label>\n  <select \n    id=\"pageSizeSelect\"\n    [value]=\"pageSize\"\n    (change)=\"changePageSize($event)\"\n    class=\"border border-gray-300 rounded-md px-2 py-2 bg-white text-gray-700\">\n    <option *ngFor=\"let size of pageSizeOptions\" [value]=\"size\">{{ size }}</option>\n  </select>\n</div>\n\n<!-- Page Information -->\n<span class=\"text-gray-500 text-sm\">\n  {{ startItem }} – {{ endItem }} of {{ length }}\n</span>\n\n<!-- Navigation Controls -->\n<button \n  [disabled]=\"isFirstPage\"\n  (click)=\"changePage(pageIndex - 1)\"\n  class=\"p-2 text-gray-500 hover:text-black disabled:opacity-50\">\n  ❮\n</button>\n\n<button \n  [disabled]=\"isLastPage\"\n  (click)=\"changePage(pageIndex + 1)\"\n  class=\"p-2 text-gray-500 hover:text-black disabled:opacity-50\">\n  ❯\n</button>\n"
         },
         {
             "name": "ProgressBarComponent",
-            "id": "component-ProgressBarComponent-78a23a78d7e5b67e6bd83b89d04b177eb6698f57f51981bfe0118b9dd1fcdddb67a4e78ce9130775a7bf75367f5e52b60e2377e467afc22057006c6abaec4b6b",
+            "id": "component-ProgressBarComponent-7d8a8dfd44a8cfebe1879bdfbcc8957089d0d26cfee79d6f7748440be200c61047da266a2203c71c427ad422483a890436b6d3cb771694e1537c50fa2c6d8bec",
             "file": "libs/ngx-tailwind-flex-ui/src/lib/progress-bar/progress-bar.component.ts",
             "encapsulation": [],
             "entryComponents": [],
@@ -1434,7 +1758,7 @@
             "propertiesClass": [
                 {
                     "name": "colorMap",
-                    "defaultValue": "{\r\n    primary: 'bg-blue-500', // Default\r\n    secondary: 'bg-yellow-500',\r\n    success: 'bg-green-500',\r\n    error: 'bg-red-500', // Warning\r\n  }",
+                    "defaultValue": "{\n    primary: 'bg-blue-500', // Default\n    secondary: 'bg-yellow-500',\n    success: 'bg-green-500',\n    error: 'bg-red-500', // Warning\n  }",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "object",
@@ -1474,7 +1798,7 @@
             "description": "",
             "rawdescription": "\n",
             "type": "component",
-            "sourceCode": "import { CommonModule } from '@angular/common';\r\nimport { Component, HostBinding, Input } from '@angular/core';\r\n\r\n@Component({\r\n  selector: 'lib-progress-bar',\r\n  templateUrl: './progress-bar.component.html',\r\n  styleUrls: ['./progress-bar.component.css'],\r\n  imports: [CommonModule],\r\n})\r\nexport class ProgressBarComponent {\r\n  /** Types: 'determinate' | 'indeterminate' | 'buffer' | 'query' */\r\n  @Input() variant: 'determinate' | 'indeterminate' | 'buffer' | 'query' = 'determinate';\r\n\r\n  /** Primary progress percentage (0-100) */\r\n  @Input() progress = 80;\r\n\r\n  /** Buffer progress (for buffer variant, 0-100) */\r\n  @Input() bufferProgress = 100;\r\n\r\n  /** Color options */\r\n  @Input() color: 'primary' | 'secondary' | 'success' | 'error' = 'primary';\r\n\r\n  @Input() class = ''; // Allow users to pass custom Tailwind classes\r\n\r\n  \r\n\r\n  private readonly colorMap = {\r\n    primary: 'bg-blue-500', // Default\r\n    secondary: 'bg-yellow-500',\r\n    success: 'bg-green-500',\r\n    error: 'bg-red-500', // Warning\r\n  };\r\n\r\n  /** Map color variants to Tailwind CSS classes */\r\n  @HostBinding('class')\r\n  get progressBarClass(): string {\r\n    return this.colorMap[this.color] || 'bg-blue-500';\r\n  }\r\n}\r\n",
+            "sourceCode": "import { CommonModule } from '@angular/common';\nimport { Component, HostBinding, Input } from '@angular/core';\n\n@Component({\n  selector: 'lib-progress-bar',\n  templateUrl: './progress-bar.component.html',\n  styleUrls: ['./progress-bar.component.css'],\n  imports: [CommonModule],\n})\nexport class ProgressBarComponent {\n  /** Types: 'determinate' | 'indeterminate' | 'buffer' | 'query' */\n  @Input() variant: 'determinate' | 'indeterminate' | 'buffer' | 'query' = 'determinate';\n\n  /** Primary progress percentage (0-100) */\n  @Input() progress = 80;\n\n  /** Buffer progress (for buffer variant, 0-100) */\n  @Input() bufferProgress = 100;\n\n  /** Color options */\n  @Input() color: 'primary' | 'secondary' | 'success' | 'error' = 'primary';\n\n  @Input() class = ''; // Allow users to pass custom Tailwind classes\n\n  \n\n  private readonly colorMap = {\n    primary: 'bg-blue-500', // Default\n    secondary: 'bg-yellow-500',\n    success: 'bg-green-500',\n    error: 'bg-red-500', // Warning\n  };\n\n  /** Map color variants to Tailwind CSS classes */\n  @HostBinding('class')\n  get progressBarClass(): string {\n    return this.colorMap[this.color] || 'bg-blue-500';\n  }\n}\n",
             "assetsDirs": [],
             "styleUrlsData": [
                 {
@@ -1497,7 +1821,7 @@
                     }
                 }
             },
-            "templateData": "<div class=\"w-full bg-gray-200 rounded-full h-4 overflow-hidden relative\">\r\n\r\n  <!-- Determinate & Buffer Primary Progress -->\r\n  <div\r\n    *ngIf=\"variant === 'determinate' || variant === 'buffer'\"\r\n    class=\"h-full transition-all duration-300\"\r\n    [ngClass]=\"progressBarClass\"\r\n    [style.width.%]=\"progress\"\r\n    role=\"progressbar\"\r\n    [attr.aria-valuenow]=\"progress\"\r\n    aria-valuemin=\"0\"\r\n    aria-valuemax=\"100\"\r\n  ></div>\r\n\r\n  <!-- Indeterminate Animation -->\r\n  <div\r\n    *ngIf=\"variant === 'indeterminate'\"\r\n    class=\"absolute top-0 left-0 h-full w-full overflow-hidden\"\r\n  >\r\n    <div\r\n      class=\"h-full w-1/3 animate-indeterminate\"\r\n      [ngClass]=\"progressBarClass\"\r\n    ></div>\r\n  </div>\r\n\r\n  <!-- Query Mode (Reversed Indeterminate) -->\r\n  <div\r\n    *ngIf=\"variant === 'query'\"\r\n    class=\"absolute top-0 left-0 h-full w-full overflow-hidden\"\r\n  >\r\n    <div\r\n      class=\"h-full w-1/3 animate-query\"\r\n      [ngClass]=\"progressBarClass\"\r\n    ></div>\r\n  </div>\r\n\r\n  <!-- Buffer Secondary Progress -->\r\n  <!-- Buffer Secondary Progress Background -->\r\n<div\r\n*ngIf=\"variant === 'buffer'\"\r\nclass=\"absolute top-0 left-0 h-full bg-gray-300 opacity-50\"\r\n[style.width.%]=\"bufferProgress\"\r\n></div>\r\n\r\n<!-- Buffer Animation Overlay -->\r\n<div\r\n*ngIf=\"variant === 'buffer'\"\r\nclass=\"absolute top-0 left-0 h-full w-full overflow-hidden\"\r\n>\r\n<div class=\"buffer-wave\"></div>\r\n</div>\r\n\r\n\r\n</div>\r\n"
+            "templateData": "<div class=\"w-full bg-gray-200 rounded-full h-4 overflow-hidden relative\">\n\n  <!-- Determinate & Buffer Primary Progress -->\n  <div\n    *ngIf=\"variant === 'determinate' || variant === 'buffer'\"\n    class=\"h-full transition-all duration-300\"\n    [ngClass]=\"progressBarClass\"\n    [style.width.%]=\"progress\"\n    role=\"progressbar\"\n    [attr.aria-valuenow]=\"progress\"\n    aria-valuemin=\"0\"\n    aria-valuemax=\"100\"\n  ></div>\n\n  <!-- Indeterminate Animation -->\n  <div\n    *ngIf=\"variant === 'indeterminate'\"\n    class=\"absolute top-0 left-0 h-full w-full overflow-hidden\"\n  >\n    <div\n      class=\"h-full w-1/3 animate-indeterminate\"\n      [ngClass]=\"progressBarClass\"\n    ></div>\n  </div>\n\n  <!-- Query Mode (Reversed Indeterminate) -->\n  <div\n    *ngIf=\"variant === 'query'\"\n    class=\"absolute top-0 left-0 h-full w-full overflow-hidden\"\n  >\n    <div\n      class=\"h-full w-1/3 animate-query\"\n      [ngClass]=\"progressBarClass\"\n    ></div>\n  </div>\n\n  <!-- Buffer Secondary Progress -->\n  <!-- Buffer Secondary Progress Background -->\n<div\n*ngIf=\"variant === 'buffer'\"\nclass=\"absolute top-0 left-0 h-full bg-gray-300 opacity-50\"\n[style.width.%]=\"bufferProgress\"\n></div>\n\n<!-- Buffer Animation Overlay -->\n<div\n*ngIf=\"variant === 'buffer'\"\nclass=\"absolute top-0 left-0 h-full w-full overflow-hidden\"\n>\n<div class=\"buffer-wave\"></div>\n</div>\n\n\n</div>\n"
         }
     ],
     "modules": [],
@@ -1511,7 +1835,7 @@
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "Story",
-                "defaultValue": "{\r\n  args: {\r\n    variant: 'accent',\r\n    disabled: false,\r\n  },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `<lib-button [variant]=\"variant\" [disabled]=\"disabled\">Accent Button</lib-button>`,\r\n  }),\r\n}"
+                "defaultValue": "{\n  args: {\n    variant: 'accent',\n    disabled: false,\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-button [variant]=\"variant\" [disabled]=\"disabled\">Accent Button</lib-button>`,\n  }),\n}"
             },
             {
                 "name": "BasicSnackBar",
@@ -1531,7 +1855,7 @@
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "Story",
-                "defaultValue": "{\r\n  args: {\r\n    color: '#ef4444', // Tailwind red-500\r\n  },\r\n}"
+                "defaultValue": "{\n  args: {\n    color: '#ef4444', // Tailwind red-500\n  },\n}"
             },
             {
                 "name": "config",
@@ -1541,7 +1865,7 @@
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "StorybookConfig",
-                "defaultValue": "{\r\n  stories: ['../**/*.@(mdx|stories.@(js|jsx|ts|tsx))'],\r\n  addons: ['@storybook/addon-essentials', '@storybook/addon-interactions'],\r\n  framework: {\r\n    name: '@storybook/angular',\r\n    options: {},\r\n  },\r\n  docs: {\r\n    autodocs: true,\r\n    defaultName: 'Docs',\r\n  },\r\n}"
+                "defaultValue": "{\n  stories: ['../**/*.@(mdx|stories.@(js|jsx|ts|tsx))'],\n  addons: ['@storybook/addon-essentials', '@storybook/addon-interactions'],\n  framework: {\n    name: '@storybook/angular',\n    options: {},\n  },\n  docs: {\n    autodocs: true,\n    defaultName: 'Docs',\n  },\n}"
             },
             {
                 "name": "ConfigurablePosition",
@@ -1561,7 +1885,7 @@
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "Story",
-                "defaultValue": "{\r\n  args: {\r\n    variant: 'primary',\r\n    class: 'text-lg px-6 py-3 bg-green-500 hover:bg-green-600',\r\n  },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `<lib-button [variant]=\"variant\" [class]=\"class\">Custom Styled Button</lib-button>`,\r\n  }),\r\n}"
+                "defaultValue": "{\n  args: {\n    variant: 'primary',\n    class: 'text-lg px-6 py-3 bg-green-500 hover:bg-green-600',\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-button [variant]=\"variant\" [class]=\"class\">Custom Styled Button</lib-button>`,\n  }),\n}"
             },
             {
                 "name": "CustomStyled",
@@ -1571,7 +1895,17 @@
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "Story",
-                "defaultValue": "{\r\n  args: {\r\n    progress: 60,\r\n    color: 'primary',\r\n    variant: 'determinate',\r\n    class: 'h-6 rounded-lg',\r\n  },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `<lib-progress-bar [progress]=\"progress\" [color]=\"color\" [variant]=\"variant\" [class]=\"class\"></lib-progress-bar>`,\r\n  }),\r\n}"
+                "defaultValue": "{\n  args: {\n    progress: 60,\n    color: 'primary',\n    variant: 'determinate',\n    class: 'h-6 rounded-lg',\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-progress-bar [progress]=\"progress\" [color]=\"color\" [variant]=\"variant\" [class]=\"class\"></lib-progress-bar>`,\n  }),\n}"
+            },
+            {
+                "name": "Default",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "libs/ngx-tailwind-flex-ui/src/lib/drawer/drawer.component.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "Template.bind({})"
             },
             {
                 "name": "Default",
@@ -1581,7 +1915,7 @@
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "Story",
-                "defaultValue": "{\r\n  args: {\r\n    name: 'home',\r\n    size: 'md',\r\n    color: 'text-gray-500',\r\n  },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `<lib-icon [name]=\"name\" [size]=\"size\" [color]=\"color\"></lib-icon>`,\r\n  }),\r\n}"
+                "defaultValue": "{\n  args: {\n    name: 'home',\n    size: 'md',\n    color: 'text-gray-500',\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-icon [name]=\"name\" [size]=\"size\" [color]=\"color\"></lib-icon>`,\n  }),\n}"
             },
             {
                 "name": "Default",
@@ -1591,7 +1925,7 @@
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "Story",
-                "defaultValue": "{\r\n  args: {},\r\n}"
+                "defaultValue": "{\n  args: {},\n}"
             },
             {
                 "name": "Default",
@@ -1611,7 +1945,7 @@
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "Story",
-                "defaultValue": "{\r\n  args: {\r\n    progress: 25,\r\n    color: \"primary\",\r\n    variant: 'determinate',\r\n    bufferProgress: 0\r\n  },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `<lib-progress-bar [progress]=\"progress\" [color]=\"color\" [variant]=\"variant\"></lib-progress-bar>`,\r\n  }),\r\n}"
+                "defaultValue": "{\n  args: {\n    progress: 25,\n    color: \"primary\",\n    variant: 'determinate',\n    bufferProgress: 0\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-progress-bar [progress]=\"progress\" [color]=\"color\" [variant]=\"variant\"></lib-progress-bar>`,\n  }),\n}"
             },
             {
                 "name": "Determinate",
@@ -1621,7 +1955,7 @@
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "Story",
-                "defaultValue": "{\r\n  args: {\r\n    mode: 'determinate',\r\n    value: 50,\r\n  },\r\n}"
+                "defaultValue": "{\n  args: {\n    mode: 'determinate',\n    value: 50,\n  },\n}"
             },
             {
                 "name": "DeterminateProgress",
@@ -1631,7 +1965,7 @@
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "Story",
-                "defaultValue": "{\r\n  args: {\r\n    mode: 'determinate',\r\n    value: 75,\r\n    size: 50,\r\n    thickness: 5,\r\n    color: '#10b981', // Tailwind green-500\r\n  },\r\n}"
+                "defaultValue": "{\n  args: {\n    mode: 'determinate',\n    value: 75,\n    size: 50,\n    thickness: 5,\n    color: '#10b981', // Tailwind green-500\n  },\n}"
             },
             {
                 "name": "Disabled",
@@ -1641,7 +1975,7 @@
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "Story",
-                "defaultValue": "{\r\n  args: {\r\n    variant: 'primary',\r\n    disabled: true,\r\n  },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `<lib-button [variant]=\"variant\" [disabled]=\"disabled\">Disabled Button</lib-button>`,\r\n  }),\r\n}"
+                "defaultValue": "{\n  args: {\n    variant: 'primary',\n    disabled: true,\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-button [variant]=\"variant\" [disabled]=\"disabled\">Disabled Button</lib-button>`,\n  }),\n}"
             },
             {
                 "name": "DismissibleError",
@@ -1661,7 +1995,7 @@
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "Story",
-                "defaultValue": "{\r\n  args: {\r\n    progress: 40,\r\n    bufferProgress: 5,\r\n    color: 'success',\r\n    variant: 'buffer',\r\n  },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `<lib-progress-bar [progress]=\"progress\" [buffer]=\"buffer\" [color]=\"color\" [variant]=\"variant\"></lib-progress-bar>`,\r\n  }),\r\n}"
+                "defaultValue": "{\n  args: {\n    progress: 40,\n    bufferProgress: 5,\n    color: 'success',\n    variant: 'buffer',\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-progress-bar [progress]=\"progress\" [buffer]=\"buffer\" [color]=\"color\" [variant]=\"variant\"></lib-progress-bar>`,\n  }),\n}"
             },
             {
                 "name": "GreenProgress",
@@ -1671,7 +2005,7 @@
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "Story",
-                "defaultValue": "{\r\n  args: {\r\n    progress: 70,\r\n    color: 'success',\r\n    variant: 'determinate',\r\n  },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `<lib-progress-bar [progress]=\"progress\" [color]=\"color\" [variant]=\"variant\"></lib-progress-bar>`,\r\n  }),\r\n}"
+                "defaultValue": "{\n  args: {\n    progress: 70,\n    color: 'success',\n    variant: 'determinate',\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-progress-bar [progress]=\"progress\" [color]=\"color\" [variant]=\"variant\"></lib-progress-bar>`,\n  }),\n}"
             },
             {
                 "name": "Large",
@@ -1681,7 +2015,7 @@
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "Story",
-                "defaultValue": "{\r\n  args: {\r\n    size: 60,\r\n  },\r\n}"
+                "defaultValue": "{\n  args: {\n    size: 60,\n  },\n}"
             },
             {
                 "name": "LargeRedIcon",
@@ -1691,7 +2025,7 @@
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "Story",
-                "defaultValue": "{\r\n  args: {\r\n    name: 'favorite',\r\n    size: 'xl',\r\n    color: 'text-red-500',\r\n  },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `<lib-icon [name]=\"name\" [size]=\"size\" [color]=\"color\"></lib-icon>`,\r\n  }),\r\n}"
+                "defaultValue": "{\n  args: {\n    name: 'favorite',\n    size: 'xl',\n    color: 'text-red-500',\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-icon [name]=\"name\" [size]=\"size\" [color]=\"color\"></lib-icon>`,\n  }),\n}"
             },
             {
                 "name": "link",
@@ -1721,7 +2055,7 @@
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "Meta<ButtonComponent>",
-                "defaultValue": "{\r\n  title: 'Components/Button',\r\n  component: ButtonComponent,\r\n  tags: ['autodocs'],\r\n  argTypes: {\r\n    variant: {\r\n      control: 'select',\r\n      options: ['primary', 'accent', 'outline', 'text'],\r\n      description: 'Button style variant',\r\n    },\r\n    disabled: {\r\n      control: 'boolean',\r\n      description: 'Disables the button',\r\n    },\r\n    class: {\r\n      control: 'text',\r\n      description: 'Additional Tailwind CSS classes for customization',\r\n    },\r\n  },\r\n}"
+                "defaultValue": "{\n  title: 'Components/Button',\n  component: ButtonComponent,\n  tags: ['autodocs'],\n  argTypes: {\n    variant: {\n      control: 'select',\n      options: ['primary', 'accent', 'outline', 'text'],\n      description: 'Button style variant',\n    },\n    disabled: {\n      control: 'boolean',\n      description: 'Disables the button',\n    },\n    class: {\n      control: 'text',\n      description: 'Additional Tailwind CSS classes for customization',\n    },\n  },\n}"
             },
             {
                 "name": "meta",
@@ -1731,7 +2065,7 @@
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "Meta<IconComponent>",
-                "defaultValue": "{\r\n  title: 'Components/Icon',\r\n  component: IconComponent,\r\n  tags: ['autodocs'],\r\n  argTypes: {\r\n    name: { control: 'text', description: 'Icon name from Material Icons' },\r\n    size: { \r\n      control: 'radio', \r\n      options: ['sm', 'md', 'lg', 'xl'], \r\n      description: 'Size of the icon' \r\n    },\r\n    color: { control: 'text', description: 'Tailwind color classes' },\r\n  },\r\n}"
+                "defaultValue": "{\n  title: 'Components/Icon',\n  component: IconComponent,\n  tags: ['autodocs'],\n  argTypes: {\n    name: { control: 'text', description: 'Icon name from Material Icons' },\n    size: { \n      control: 'radio', \n      options: ['sm', 'md', 'lg', 'xl'], \n      description: 'Size of the icon' \n    },\n    color: { control: 'text', description: 'Tailwind color classes' },\n  },\n}"
             },
             {
                 "name": "meta",
@@ -1741,7 +2075,7 @@
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "Meta<LoadingSpinnerComponent>",
-                "defaultValue": "{\r\n  title: 'Components/LoadingSpinnerComponent',\r\n  component: LoadingSpinnerComponent,\r\n  tags: ['autodocs'],\r\n  argTypes: {\r\n    mode: {\r\n      control: 'select',\r\n      options: ['determinate', 'indeterminate'],\r\n      description: 'Loading state',\r\n    },\r\n    value: {\r\n      control: 'number',\r\n      description: 'Progress value (0-100) for determinate mode',\r\n    },\r\n    size: { control: 'number', description: 'Diameter in pixels' },\r\n    thickness: { control: 'number', description: 'Stroke width in pixels' },\r\n    color: {\r\n      control: 'color',\r\n      description: 'Spinner color (hex or Tailwind color)',\r\n    },\r\n  },\r\n}"
+                "defaultValue": "{\n  title: 'Components/LoadingSpinnerComponent',\n  component: LoadingSpinnerComponent,\n  tags: ['autodocs'],\n  argTypes: {\n    mode: {\n      control: 'select',\n      options: ['determinate', 'indeterminate'],\n      description: 'Loading state',\n    },\n    value: {\n      control: 'number',\n      description: 'Progress value (0-100) for determinate mode',\n    },\n    size: { control: 'number', description: 'Diameter in pixels' },\n    thickness: { control: 'number', description: 'Stroke width in pixels' },\n    color: {\n      control: 'color',\n      description: 'Spinner color (hex or Tailwind color)',\n    },\n  },\n}"
             },
             {
                 "name": "meta",
@@ -1751,7 +2085,7 @@
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "Meta<ProgressBarComponent>",
-                "defaultValue": "{\r\n  title: 'Components/Progress Bar',\r\n  component: ProgressBarComponent,\r\n  tags: ['autodocs'],\r\n  argTypes: {\r\n    progress: {\r\n      control: { type: 'range', min: 0, max: 100, step: 1 },\r\n      description: 'Progress percentage (0 to 100)',\r\n    },\r\n    // buffer: {\r\n    //   control: { type: 'range', min: 0, max: 100, step: 1 },\r\n    //   description: 'Buffer progress percentage (used in buffer variant)',\r\n    // },\r\n    color: {\r\n      control: 'select',\r\n      options: ['primary', 'secondary', 'success', 'error'],\r\n      description: 'Color of the progress bar',\r\n    },\r\n    variant: {\r\n      control: 'select',\r\n      options: ['determinate', 'indeterminate', 'buffer', 'query'],\r\n      description: 'Progress bar type',\r\n    },\r\n    // class: {\r\n    //   control: 'text',\r\n    //   description: 'Additional Tailwind CSS classes for customization',\r\n    // },\r\n  },\r\n}"
+                "defaultValue": "{\n  title: 'Components/Progress Bar',\n  component: ProgressBarComponent,\n  tags: ['autodocs'],\n  argTypes: {\n    progress: {\n      control: { type: 'range', min: 0, max: 100, step: 1 },\n      description: 'Progress percentage (0 to 100)',\n    },\n    // buffer: {\n    //   control: { type: 'range', min: 0, max: 100, step: 1 },\n    //   description: 'Buffer progress percentage (used in buffer variant)',\n    // },\n    color: {\n      control: 'select',\n      options: ['primary', 'secondary', 'success', 'error'],\n      description: 'Color of the progress bar',\n    },\n    variant: {\n      control: 'select',\n      options: ['determinate', 'indeterminate', 'buffer', 'query'],\n      description: 'Progress bar type',\n    },\n    // class: {\n    //   control: 'text',\n    //   description: 'Additional Tailwind CSS classes for customization',\n    // },\n  },\n}"
             },
             {
                 "name": "Outline",
@@ -1761,7 +2095,7 @@
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "Story",
-                "defaultValue": "{\r\n  args: {\r\n    variant: 'outline',\r\n    disabled: false,\r\n  },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `<lib-button [variant]=\"variant\" [disabled]=\"disabled\">Outline Button</lib-button>`,\r\n  }),\r\n}"
+                "defaultValue": "{\n  args: {\n    variant: 'outline',\n    disabled: false,\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-button [variant]=\"variant\" [disabled]=\"disabled\">Outline Button</lib-button>`,\n  }),\n}"
             },
             {
                 "name": "parameters",
@@ -1771,7 +2105,7 @@
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "object",
-                "defaultValue": "{\r\n  actions: { argTypesRegex: '^on[A-Z].*' },\r\n  controls: {\r\n    matchers: {\r\n      color: /(background|color)$/i,\r\n      date: /Date$/,\r\n    },\r\n  },\r\n}"
+                "defaultValue": "{\n  actions: { argTypesRegex: '^on[A-Z].*' },\n  controls: {\n    matchers: {\n      color: /(background|color)$/i,\n      date: /Date$/,\n    },\n  },\n}"
             },
             {
                 "name": "Primary",
@@ -1781,7 +2115,7 @@
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "Story",
-                "defaultValue": "{\r\n  args: {\r\n    variant: 'primary',\r\n    disabled: false,\r\n  },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `<lib-button [variant]=\"variant\" [disabled]=\"disabled\">Primary Button</lib-button>`,\r\n  }),\r\n}"
+                "defaultValue": "{\n  args: {\n    variant: 'primary',\n    disabled: false,\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-button [variant]=\"variant\" [disabled]=\"disabled\">Primary Button</lib-button>`,\n  }),\n}"
             },
             {
                 "name": "RedIndeterminate",
@@ -1791,7 +2125,17 @@
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "Story",
-                "defaultValue": "{\r\n  args: {\r\n    color: 'error',\r\n    variant: 'indeterminate',\r\n  },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `<lib-progress-bar [color]=\"color\" [variant]=\"variant\"></lib-progress-bar>`,\r\n  }),\r\n}"
+                "defaultValue": "{\n  args: {\n    color: 'error',\n    variant: 'indeterminate',\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-progress-bar [color]=\"color\" [variant]=\"variant\"></lib-progress-bar>`,\n  }),\n}"
+            },
+            {
+                "name": "RightMini",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "libs/ngx-tailwind-flex-ui/src/lib/drawer/drawer.component.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "Template.bind({})"
             },
             {
                 "name": "SmallBlueIcon",
@@ -1801,7 +2145,7 @@
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "Story",
-                "defaultValue": "{\r\n  args: {\r\n    name: 'star',\r\n    size: 'sm',\r\n    color: 'text-blue-500',\r\n  },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `<lib-icon [name]=\"name\" [size]=\"size\" [color]=\"color\"></lib-icon>`,\r\n  }),\r\n}"
+                "defaultValue": "{\n  args: {\n    name: 'star',\n    size: 'sm',\n    color: 'text-blue-500',\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-icon [name]=\"name\" [size]=\"size\" [color]=\"color\"></lib-icon>`,\n  }),\n}"
             },
             {
                 "name": "StackedAlerts",
@@ -1824,6 +2168,26 @@
                 "defaultValue": "{\r\n  args: {\r\n    message: 'Data saved successfully',\r\n    type: 'success',\r\n    action: 'Undo',\r\n    duration: 3000,\r\n    position: 'bottom-center',\r\n  },\r\n}"
             },
             {
+                "name": "Template",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "libs/ngx-tailwind-flex-ui/src/lib/drawer/drawer.component.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "StoryFn<DrawerComponent>",
+                "defaultValue": "(args) => ({\r\n  props: {\r\n    ...args,\r\n    handleToggle: () => {\r\n      args.open = !args.open;\r\n      args.openChange(args.open); // manually emit for Storybook\r\n    },\r\n  },\r\n  template: `\r\n    <lib-drawer [mode]=\"mode\" [position]=\"position\" [open]=\"open\" (openChange)=\"openChange($event)\">\r\n      <div drawerContent class=\"h-full p-4 bg-blue-100\">\r\n        <p class=\"font-semibold\">Drawer content ({{ mode }} | {{ position }})</p>\r\n      </div>\r\n      <div mainContent class=\"p-4\">\r\n        <p>Main content area</p>\r\n        <button\r\n          *ngIf=\"mode === 'temporary'\"\r\n          (click)=\"handleToggle()\"\r\n          class=\"mt-4 px-4 py-2 bg-blue-600 text-white rounded\"\r\n        >\r\n          Toggle Drawer\r\n        </button>\r\n      </div>\r\n    </lib-drawer>\r\n  `,\r\n})"
+            },
+            {
+                "name": "Temporary",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "libs/ngx-tailwind-flex-ui/src/lib/drawer/drawer.component.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "Template.bind({})"
+            },
+            {
                 "name": "Text",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
@@ -1831,7 +2195,7 @@
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "Story",
-                "defaultValue": "{\r\n  args: {\r\n    variant: 'text',\r\n    disabled: false,\r\n  },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `<lib-button [variant]=\"variant\" [disabled]=\"disabled\">Text Button</lib-button>`,\r\n  }),\r\n}"
+                "defaultValue": "{\n  args: {\n    variant: 'text',\n    disabled: false,\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-button [variant]=\"variant\" [disabled]=\"disabled\">Text Button</lib-button>`,\n  }),\n}"
             },
             {
                 "name": "Thick",
@@ -1841,7 +2205,7 @@
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "Story",
-                "defaultValue": "{\r\n  args: {\r\n    thickness: 6,\r\n  },\r\n}"
+                "defaultValue": "{\n  args: {\n    thickness: 6,\n  },\n}"
             },
             {
                 "name": "WarningWithCustomIcon",
@@ -1923,7 +2287,7 @@
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "Story",
-                    "defaultValue": "{\r\n  args: {\r\n    variant: 'accent',\r\n    disabled: false,\r\n  },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `<lib-button [variant]=\"variant\" [disabled]=\"disabled\">Accent Button</lib-button>`,\r\n  }),\r\n}"
+                    "defaultValue": "{\n  args: {\n    variant: 'accent',\n    disabled: false,\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-button [variant]=\"variant\" [disabled]=\"disabled\">Accent Button</lib-button>`,\n  }),\n}"
                 },
                 {
                     "name": "CustomStyled",
@@ -1933,7 +2297,7 @@
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "Story",
-                    "defaultValue": "{\r\n  args: {\r\n    variant: 'primary',\r\n    class: 'text-lg px-6 py-3 bg-green-500 hover:bg-green-600',\r\n  },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `<lib-button [variant]=\"variant\" [class]=\"class\">Custom Styled Button</lib-button>`,\r\n  }),\r\n}"
+                    "defaultValue": "{\n  args: {\n    variant: 'primary',\n    class: 'text-lg px-6 py-3 bg-green-500 hover:bg-green-600',\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-button [variant]=\"variant\" [class]=\"class\">Custom Styled Button</lib-button>`,\n  }),\n}"
                 },
                 {
                     "name": "Disabled",
@@ -1943,7 +2307,7 @@
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "Story",
-                    "defaultValue": "{\r\n  args: {\r\n    variant: 'primary',\r\n    disabled: true,\r\n  },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `<lib-button [variant]=\"variant\" [disabled]=\"disabled\">Disabled Button</lib-button>`,\r\n  }),\r\n}"
+                    "defaultValue": "{\n  args: {\n    variant: 'primary',\n    disabled: true,\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-button [variant]=\"variant\" [disabled]=\"disabled\">Disabled Button</lib-button>`,\n  }),\n}"
                 },
                 {
                     "name": "meta",
@@ -1953,7 +2317,7 @@
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "Meta<ButtonComponent>",
-                    "defaultValue": "{\r\n  title: 'Components/Button',\r\n  component: ButtonComponent,\r\n  tags: ['autodocs'],\r\n  argTypes: {\r\n    variant: {\r\n      control: 'select',\r\n      options: ['primary', 'accent', 'outline', 'text'],\r\n      description: 'Button style variant',\r\n    },\r\n    disabled: {\r\n      control: 'boolean',\r\n      description: 'Disables the button',\r\n    },\r\n    class: {\r\n      control: 'text',\r\n      description: 'Additional Tailwind CSS classes for customization',\r\n    },\r\n  },\r\n}"
+                    "defaultValue": "{\n  title: 'Components/Button',\n  component: ButtonComponent,\n  tags: ['autodocs'],\n  argTypes: {\n    variant: {\n      control: 'select',\n      options: ['primary', 'accent', 'outline', 'text'],\n      description: 'Button style variant',\n    },\n    disabled: {\n      control: 'boolean',\n      description: 'Disables the button',\n    },\n    class: {\n      control: 'text',\n      description: 'Additional Tailwind CSS classes for customization',\n    },\n  },\n}"
                 },
                 {
                     "name": "Outline",
@@ -1963,7 +2327,7 @@
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "Story",
-                    "defaultValue": "{\r\n  args: {\r\n    variant: 'outline',\r\n    disabled: false,\r\n  },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `<lib-button [variant]=\"variant\" [disabled]=\"disabled\">Outline Button</lib-button>`,\r\n  }),\r\n}"
+                    "defaultValue": "{\n  args: {\n    variant: 'outline',\n    disabled: false,\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-button [variant]=\"variant\" [disabled]=\"disabled\">Outline Button</lib-button>`,\n  }),\n}"
                 },
                 {
                     "name": "Primary",
@@ -1973,7 +2337,7 @@
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "Story",
-                    "defaultValue": "{\r\n  args: {\r\n    variant: 'primary',\r\n    disabled: false,\r\n  },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `<lib-button [variant]=\"variant\" [disabled]=\"disabled\">Primary Button</lib-button>`,\r\n  }),\r\n}"
+                    "defaultValue": "{\n  args: {\n    variant: 'primary',\n    disabled: false,\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-button [variant]=\"variant\" [disabled]=\"disabled\">Primary Button</lib-button>`,\n  }),\n}"
                 },
                 {
                     "name": "Text",
@@ -1983,7 +2347,7 @@
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "Story",
-                    "defaultValue": "{\r\n  args: {\r\n    variant: 'text',\r\n    disabled: false,\r\n  },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `<lib-button [variant]=\"variant\" [disabled]=\"disabled\">Text Button</lib-button>`,\r\n  }),\r\n}"
+                    "defaultValue": "{\n  args: {\n    variant: 'text',\n    disabled: false,\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-button [variant]=\"variant\" [disabled]=\"disabled\">Text Button</lib-button>`,\n  }),\n}"
                 }
             ],
             "libs/ngx-tailwind-flex-ui/src/lib/alert/alert.component.stories.ts": [
@@ -2067,7 +2431,7 @@
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "Story",
-                    "defaultValue": "{\r\n  args: {\r\n    color: '#ef4444', // Tailwind red-500\r\n  },\r\n}"
+                    "defaultValue": "{\n  args: {\n    color: '#ef4444', // Tailwind red-500\n  },\n}"
                 },
                 {
                     "name": "Default",
@@ -2077,7 +2441,7 @@
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "Story",
-                    "defaultValue": "{\r\n  args: {},\r\n}"
+                    "defaultValue": "{\n  args: {},\n}"
                 },
                 {
                     "name": "Determinate",
@@ -2087,7 +2451,7 @@
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "Story",
-                    "defaultValue": "{\r\n  args: {\r\n    mode: 'determinate',\r\n    value: 50,\r\n  },\r\n}"
+                    "defaultValue": "{\n  args: {\n    mode: 'determinate',\n    value: 50,\n  },\n}"
                 },
                 {
                     "name": "DeterminateProgress",
@@ -2097,7 +2461,7 @@
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "Story",
-                    "defaultValue": "{\r\n  args: {\r\n    mode: 'determinate',\r\n    value: 75,\r\n    size: 50,\r\n    thickness: 5,\r\n    color: '#10b981', // Tailwind green-500\r\n  },\r\n}"
+                    "defaultValue": "{\n  args: {\n    mode: 'determinate',\n    value: 75,\n    size: 50,\n    thickness: 5,\n    color: '#10b981', // Tailwind green-500\n  },\n}"
                 },
                 {
                     "name": "Large",
@@ -2107,7 +2471,7 @@
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "Story",
-                    "defaultValue": "{\r\n  args: {\r\n    size: 60,\r\n  },\r\n}"
+                    "defaultValue": "{\n  args: {\n    size: 60,\n  },\n}"
                 },
                 {
                     "name": "meta",
@@ -2117,7 +2481,7 @@
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "Meta<LoadingSpinnerComponent>",
-                    "defaultValue": "{\r\n  title: 'Components/LoadingSpinnerComponent',\r\n  component: LoadingSpinnerComponent,\r\n  tags: ['autodocs'],\r\n  argTypes: {\r\n    mode: {\r\n      control: 'select',\r\n      options: ['determinate', 'indeterminate'],\r\n      description: 'Loading state',\r\n    },\r\n    value: {\r\n      control: 'number',\r\n      description: 'Progress value (0-100) for determinate mode',\r\n    },\r\n    size: { control: 'number', description: 'Diameter in pixels' },\r\n    thickness: { control: 'number', description: 'Stroke width in pixels' },\r\n    color: {\r\n      control: 'color',\r\n      description: 'Spinner color (hex or Tailwind color)',\r\n    },\r\n  },\r\n}"
+                    "defaultValue": "{\n  title: 'Components/LoadingSpinnerComponent',\n  component: LoadingSpinnerComponent,\n  tags: ['autodocs'],\n  argTypes: {\n    mode: {\n      control: 'select',\n      options: ['determinate', 'indeterminate'],\n      description: 'Loading state',\n    },\n    value: {\n      control: 'number',\n      description: 'Progress value (0-100) for determinate mode',\n    },\n    size: { control: 'number', description: 'Diameter in pixels' },\n    thickness: { control: 'number', description: 'Stroke width in pixels' },\n    color: {\n      control: 'color',\n      description: 'Spinner color (hex or Tailwind color)',\n    },\n  },\n}"
                 },
                 {
                     "name": "Thick",
@@ -2127,7 +2491,7 @@
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "Story",
-                    "defaultValue": "{\r\n  args: {\r\n    thickness: 6,\r\n  },\r\n}"
+                    "defaultValue": "{\n  args: {\n    thickness: 6,\n  },\n}"
                 }
             ],
             "libs/ngx-tailwind-flex-ui/.storybook/main.ts": [
@@ -2139,7 +2503,7 @@
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "StorybookConfig",
-                    "defaultValue": "{\r\n  stories: ['../**/*.@(mdx|stories.@(js|jsx|ts|tsx))'],\r\n  addons: ['@storybook/addon-essentials', '@storybook/addon-interactions'],\r\n  framework: {\r\n    name: '@storybook/angular',\r\n    options: {},\r\n  },\r\n  docs: {\r\n    autodocs: true,\r\n    defaultName: 'Docs',\r\n  },\r\n}"
+                    "defaultValue": "{\n  stories: ['../**/*.@(mdx|stories.@(js|jsx|ts|tsx))'],\n  addons: ['@storybook/addon-essentials', '@storybook/addon-interactions'],\n  framework: {\n    name: '@storybook/angular',\n    options: {},\n  },\n  docs: {\n    autodocs: true,\n    defaultName: 'Docs',\n  },\n}"
                 }
             ],
             "libs/ngx-tailwind-flex-ui/src/lib/progress-bar/progress-bar.component.stories.ts": [
@@ -2151,7 +2515,7 @@
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "Story",
-                    "defaultValue": "{\r\n  args: {\r\n    progress: 60,\r\n    color: 'primary',\r\n    variant: 'determinate',\r\n    class: 'h-6 rounded-lg',\r\n  },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `<lib-progress-bar [progress]=\"progress\" [color]=\"color\" [variant]=\"variant\" [class]=\"class\"></lib-progress-bar>`,\r\n  }),\r\n}"
+                    "defaultValue": "{\n  args: {\n    progress: 60,\n    color: 'primary',\n    variant: 'determinate',\n    class: 'h-6 rounded-lg',\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-progress-bar [progress]=\"progress\" [color]=\"color\" [variant]=\"variant\" [class]=\"class\"></lib-progress-bar>`,\n  }),\n}"
                 },
                 {
                     "name": "Default",
@@ -2161,7 +2525,7 @@
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "Story",
-                    "defaultValue": "{\r\n  args: {\r\n    progress: 25,\r\n    color: \"primary\",\r\n    variant: 'determinate',\r\n    bufferProgress: 0\r\n  },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `<lib-progress-bar [progress]=\"progress\" [color]=\"color\" [variant]=\"variant\"></lib-progress-bar>`,\r\n  }),\r\n}"
+                    "defaultValue": "{\n  args: {\n    progress: 25,\n    color: \"primary\",\n    variant: 'determinate',\n    bufferProgress: 0\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-progress-bar [progress]=\"progress\" [color]=\"color\" [variant]=\"variant\"></lib-progress-bar>`,\n  }),\n}"
                 },
                 {
                     "name": "GreenBuffer",
@@ -2171,7 +2535,7 @@
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "Story",
-                    "defaultValue": "{\r\n  args: {\r\n    progress: 40,\r\n    bufferProgress: 5,\r\n    color: 'success',\r\n    variant: 'buffer',\r\n  },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `<lib-progress-bar [progress]=\"progress\" [buffer]=\"buffer\" [color]=\"color\" [variant]=\"variant\"></lib-progress-bar>`,\r\n  }),\r\n}"
+                    "defaultValue": "{\n  args: {\n    progress: 40,\n    bufferProgress: 5,\n    color: 'success',\n    variant: 'buffer',\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-progress-bar [progress]=\"progress\" [buffer]=\"buffer\" [color]=\"color\" [variant]=\"variant\"></lib-progress-bar>`,\n  }),\n}"
                 },
                 {
                     "name": "GreenProgress",
@@ -2181,7 +2545,7 @@
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "Story",
-                    "defaultValue": "{\r\n  args: {\r\n    progress: 70,\r\n    color: 'success',\r\n    variant: 'determinate',\r\n  },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `<lib-progress-bar [progress]=\"progress\" [color]=\"color\" [variant]=\"variant\"></lib-progress-bar>`,\r\n  }),\r\n}"
+                    "defaultValue": "{\n  args: {\n    progress: 70,\n    color: 'success',\n    variant: 'determinate',\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-progress-bar [progress]=\"progress\" [color]=\"color\" [variant]=\"variant\"></lib-progress-bar>`,\n  }),\n}"
                 },
                 {
                     "name": "meta",
@@ -2191,7 +2555,7 @@
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "Meta<ProgressBarComponent>",
-                    "defaultValue": "{\r\n  title: 'Components/Progress Bar',\r\n  component: ProgressBarComponent,\r\n  tags: ['autodocs'],\r\n  argTypes: {\r\n    progress: {\r\n      control: { type: 'range', min: 0, max: 100, step: 1 },\r\n      description: 'Progress percentage (0 to 100)',\r\n    },\r\n    // buffer: {\r\n    //   control: { type: 'range', min: 0, max: 100, step: 1 },\r\n    //   description: 'Buffer progress percentage (used in buffer variant)',\r\n    // },\r\n    color: {\r\n      control: 'select',\r\n      options: ['primary', 'secondary', 'success', 'error'],\r\n      description: 'Color of the progress bar',\r\n    },\r\n    variant: {\r\n      control: 'select',\r\n      options: ['determinate', 'indeterminate', 'buffer', 'query'],\r\n      description: 'Progress bar type',\r\n    },\r\n    // class: {\r\n    //   control: 'text',\r\n    //   description: 'Additional Tailwind CSS classes for customization',\r\n    // },\r\n  },\r\n}"
+                    "defaultValue": "{\n  title: 'Components/Progress Bar',\n  component: ProgressBarComponent,\n  tags: ['autodocs'],\n  argTypes: {\n    progress: {\n      control: { type: 'range', min: 0, max: 100, step: 1 },\n      description: 'Progress percentage (0 to 100)',\n    },\n    // buffer: {\n    //   control: { type: 'range', min: 0, max: 100, step: 1 },\n    //   description: 'Buffer progress percentage (used in buffer variant)',\n    // },\n    color: {\n      control: 'select',\n      options: ['primary', 'secondary', 'success', 'error'],\n      description: 'Color of the progress bar',\n    },\n    variant: {\n      control: 'select',\n      options: ['determinate', 'indeterminate', 'buffer', 'query'],\n      description: 'Progress bar type',\n    },\n    // class: {\n    //   control: 'text',\n    //   description: 'Additional Tailwind CSS classes for customization',\n    // },\n  },\n}"
                 },
                 {
                     "name": "RedIndeterminate",
@@ -2201,7 +2565,49 @@
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "Story",
-                    "defaultValue": "{\r\n  args: {\r\n    color: 'error',\r\n    variant: 'indeterminate',\r\n  },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `<lib-progress-bar [color]=\"color\" [variant]=\"variant\"></lib-progress-bar>`,\r\n  }),\r\n}"
+                    "defaultValue": "{\n  args: {\n    color: 'error',\n    variant: 'indeterminate',\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-progress-bar [color]=\"color\" [variant]=\"variant\"></lib-progress-bar>`,\n  }),\n}"
+                }
+            ],
+            "libs/ngx-tailwind-flex-ui/src/lib/drawer/drawer.component.stories.ts": [
+                {
+                    "name": "Default",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "libs/ngx-tailwind-flex-ui/src/lib/drawer/drawer.component.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "Template.bind({})"
+                },
+                {
+                    "name": "RightMini",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "libs/ngx-tailwind-flex-ui/src/lib/drawer/drawer.component.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "Template.bind({})"
+                },
+                {
+                    "name": "Template",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "libs/ngx-tailwind-flex-ui/src/lib/drawer/drawer.component.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "StoryFn<DrawerComponent>",
+                    "defaultValue": "(args) => ({\r\n  props: {\r\n    ...args,\r\n    handleToggle: () => {\r\n      args.open = !args.open;\r\n      args.openChange(args.open); // manually emit for Storybook\r\n    },\r\n  },\r\n  template: `\r\n    <lib-drawer [mode]=\"mode\" [position]=\"position\" [open]=\"open\" (openChange)=\"openChange($event)\">\r\n      <div drawerContent class=\"h-full p-4 bg-blue-100\">\r\n        <p class=\"font-semibold\">Drawer content ({{ mode }} | {{ position }})</p>\r\n      </div>\r\n      <div mainContent class=\"p-4\">\r\n        <p>Main content area</p>\r\n        <button\r\n          *ngIf=\"mode === 'temporary'\"\r\n          (click)=\"handleToggle()\"\r\n          class=\"mt-4 px-4 py-2 bg-blue-600 text-white rounded\"\r\n        >\r\n          Toggle Drawer\r\n        </button>\r\n      </div>\r\n    </lib-drawer>\r\n  `,\r\n})"
+                },
+                {
+                    "name": "Temporary",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "libs/ngx-tailwind-flex-ui/src/lib/drawer/drawer.component.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "Template.bind({})"
                 }
             ],
             "libs/ngx-tailwind-flex-ui/src/lib/icon/icon.stories.ts": [
@@ -2213,7 +2619,7 @@
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "Story",
-                    "defaultValue": "{\r\n  args: {\r\n    name: 'home',\r\n    size: 'md',\r\n    color: 'text-gray-500',\r\n  },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `<lib-icon [name]=\"name\" [size]=\"size\" [color]=\"color\"></lib-icon>`,\r\n  }),\r\n}"
+                    "defaultValue": "{\n  args: {\n    name: 'home',\n    size: 'md',\n    color: 'text-gray-500',\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-icon [name]=\"name\" [size]=\"size\" [color]=\"color\"></lib-icon>`,\n  }),\n}"
                 },
                 {
                     "name": "LargeRedIcon",
@@ -2223,7 +2629,7 @@
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "Story",
-                    "defaultValue": "{\r\n  args: {\r\n    name: 'favorite',\r\n    size: 'xl',\r\n    color: 'text-red-500',\r\n  },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `<lib-icon [name]=\"name\" [size]=\"size\" [color]=\"color\"></lib-icon>`,\r\n  }),\r\n}"
+                    "defaultValue": "{\n  args: {\n    name: 'favorite',\n    size: 'xl',\n    color: 'text-red-500',\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-icon [name]=\"name\" [size]=\"size\" [color]=\"color\"></lib-icon>`,\n  }),\n}"
                 },
                 {
                     "name": "meta",
@@ -2233,7 +2639,7 @@
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "Meta<IconComponent>",
-                    "defaultValue": "{\r\n  title: 'Components/Icon',\r\n  component: IconComponent,\r\n  tags: ['autodocs'],\r\n  argTypes: {\r\n    name: { control: 'text', description: 'Icon name from Material Icons' },\r\n    size: { \r\n      control: 'radio', \r\n      options: ['sm', 'md', 'lg', 'xl'], \r\n      description: 'Size of the icon' \r\n    },\r\n    color: { control: 'text', description: 'Tailwind color classes' },\r\n  },\r\n}"
+                    "defaultValue": "{\n  title: 'Components/Icon',\n  component: IconComponent,\n  tags: ['autodocs'],\n  argTypes: {\n    name: { control: 'text', description: 'Icon name from Material Icons' },\n    size: { \n      control: 'radio', \n      options: ['sm', 'md', 'lg', 'xl'], \n      description: 'Size of the icon' \n    },\n    color: { control: 'text', description: 'Tailwind color classes' },\n  },\n}"
                 },
                 {
                     "name": "SmallBlueIcon",
@@ -2243,7 +2649,7 @@
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "Story",
-                    "defaultValue": "{\r\n  args: {\r\n    name: 'star',\r\n    size: 'sm',\r\n    color: 'text-blue-500',\r\n  },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `<lib-icon [name]=\"name\" [size]=\"size\" [color]=\"color\"></lib-icon>`,\r\n  }),\r\n}"
+                    "defaultValue": "{\n  args: {\n    name: 'star',\n    size: 'sm',\n    color: 'text-blue-500',\n  },\n  render: (args) => ({\n    props: args,\n    template: `<lib-icon [name]=\"name\" [size]=\"size\" [color]=\"color\"></lib-icon>`,\n  }),\n}"
                 }
             ],
             "libs/ngx-tailwind-flex-ui/src/lib/paginator/paginator.component.stories.ts": [
@@ -2277,7 +2683,7 @@
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "object",
-                    "defaultValue": "{\r\n  actions: { argTypesRegex: '^on[A-Z].*' },\r\n  controls: {\r\n    matchers: {\r\n      color: /(background|color)$/i,\r\n      date: /Date$/,\r\n    },\r\n  },\r\n}"
+                    "defaultValue": "{\n  actions: { argTypesRegex: '^on[A-Z].*' },\n  controls: {\n    matchers: {\n      color: /(background|color)$/i,\n      date: /Date$/,\n    },\n  },\n}"
                 }
             ]
         },
@@ -2571,6 +2977,55 @@
                 "name": "ButtonComponent",
                 "coveragePercent": 0,
                 "coverageCount": "0/5",
+                "status": "low"
+            },
+            {
+                "filePath": "libs/ngx-tailwind-flex-ui/src/lib/drawer/drawer.component.stories.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "Default",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "libs/ngx-tailwind-flex-ui/src/lib/drawer/drawer.component.stories.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "RightMini",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "libs/ngx-tailwind-flex-ui/src/lib/drawer/drawer.component.stories.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "Template",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "libs/ngx-tailwind-flex-ui/src/lib/drawer/drawer.component.stories.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "Temporary",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "libs/ngx-tailwind-flex-ui/src/lib/drawer/drawer.component.ts",
+                "type": "component",
+                "linktype": "component",
+                "name": "DrawerComponent",
+                "coveragePercent": 0,
+                "coverageCount": "0/15",
                 "status": "low"
             },
             {

--- a/libs/ngx-tailwind-flex-ui/src/lib/drawer/drawer.component.css
+++ b/libs/ngx-tailwind-flex-ui/src/lib/drawer/drawer.component.css
@@ -1,0 +1,14 @@
+:host {
+    display: block;
+    color: rgb(129, 126, 133);
+  }
+  
+  .drawer-content {
+    width: 100%;
+    height: 100%;
+    position: relative;
+  }
+  
+  .opacity-50 {
+    background-color: rgba(180, 28, 28, 0.5);
+  }

--- a/libs/ngx-tailwind-flex-ui/src/lib/drawer/drawer.component.html
+++ b/libs/ngx-tailwind-flex-ui/src/lib/drawer/drawer.component.html
@@ -1,0 +1,46 @@
+<!-- Drawer Container -->
+<div
+  [class]="drawerClasses"
+  [class.hidden]="!open"
+  role="dialog"
+  aria-labelledby="drawer-title"
+  [attr.aria-hidden]="!open"
+>
+  <!-- Drawer Content -->
+  <div class="relative flex flex-col h-full bg-white shadow-xl p-4">
+    <!-- Close Button -->
+    <button
+      *ngIf="isClosable"
+      class="absolute top-4 right-4 text-gray-600 hover:text-gray-800"
+      (click)="close()"
+      aria-label="Close Drawer"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        class="h-6 w-6"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+        aria-hidden="true"
+      >
+        <path
+          fill-rule="evenodd"
+          d="M10 9.293l5.147-5.146a1 1 0 111.414 1.414L11.414 10l5.147 5.146a1 1 0 11-1.414 1.414L10 11.414l-5.146 5.147a1 1 0 11-1.414-1.414L8.586 10 3.439 4.854a1 1 0 111.414-1.414L10 9.293z"
+          clip-rule="evenodd"
+        />
+      </svg>
+    </button>
+
+    <!-- Custom Content -->
+    <ng-content></ng-content>
+  </div>
+</div>
+
+<!-- Backdrop Overlay -->
+<div
+  *ngIf="backdrop"
+  class="fixed inset-0 bg-black bg-opacity-50 z-30"
+  (click)="close()"
+  [attr.aria-hidden]="true"
+  role="button"
+  tabindex="0"
+></div>

--- a/libs/ngx-tailwind-flex-ui/src/lib/drawer/drawer.component.spec.ts
+++ b/libs/ngx-tailwind-flex-ui/src/lib/drawer/drawer.component.spec.ts
@@ -1,0 +1,149 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CommonModule } from '@angular/common';
+import { DrawerComponent } from './drawer.component';
+
+describe('DrawerComponent', () => {
+  let component: DrawerComponent;
+  let fixture: ComponentFixture<DrawerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CommonModule, DrawerComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DrawerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should not render drawer content when closed', () => {
+    component.open = false;
+    fixture.detectChanges();
+    const drawer = fixture.nativeElement.querySelector('[role="dialog"]');
+    expect(drawer.classList.contains('hidden')).toBe(true);
+  });
+
+  it('should render drawer content when open', () => {
+    component.open = true;
+    fixture.detectChanges();
+    const drawer = fixture.nativeElement.querySelector('[role="dialog"]');
+    expect(drawer.classList.contains('hidden')).toBe(false);
+  });
+
+  it('should show backdrop in temporary mode when open', () => {
+    component.mode = 'temporary';
+    component.open = true;
+    fixture.detectChanges();
+    const backdrop = fixture.nativeElement.querySelector('.bg-black.bg-opacity-50');
+    expect(backdrop).not.toBeNull();
+  });
+
+  it('should not show backdrop in persistent or mini modes', () => {
+    component.mode = 'persistent';
+    component.open = true;
+    fixture.detectChanges();
+    let backdrop = fixture.nativeElement.querySelector('.bg-black.bg-opacity-50');
+    expect(backdrop).toBeNull();
+
+    component.mode = 'mini';
+    component.open = true;
+    fixture.detectChanges();
+    backdrop = fixture.nativeElement.querySelector('.bg-black.bg-opacity-50');
+    expect(backdrop).toBeNull();
+  });
+
+  it('should emit openChange and close on backdrop click', () => {
+    component.mode = 'temporary';
+    component.open = true;
+    fixture.detectChanges();
+
+    jest.spyOn(component.openChange, 'emit');
+    jest.spyOn(component, 'close');
+
+    const backdrop = fixture.nativeElement.querySelector('.bg-black.bg-opacity-50');
+    if (backdrop) {
+      backdrop.click();
+      fixture.detectChanges();
+      expect(component.openChange.emit).toHaveBeenCalledWith(false);
+      expect(component.close).toHaveBeenCalled();
+    } else {
+      expect(backdrop).not.toBeNull(); // Fail explicitly
+    }
+  });
+
+  it('should close the drawer on Escape key (temporary mode only)', () => {
+    component.mode = 'temporary';
+    component.open = true;
+    fixture.detectChanges();
+
+    jest.spyOn(component, 'close');
+
+    const event = new KeyboardEvent('keydown', { key: 'Escape' });
+    document.dispatchEvent(event);
+    fixture.detectChanges();
+
+    expect(component.close).toHaveBeenCalled();
+  });
+
+  it('should not close on Escape in persistent or mini modes', () => {
+    jest.spyOn(component, 'close');
+
+    component.mode = 'persistent';
+    component.open = true;
+    fixture.detectChanges();
+
+    let event = new KeyboardEvent('keydown', { key: 'Escape' });
+    document.dispatchEvent(event);
+    fixture.detectChanges();
+    expect(component.close).not.toHaveBeenCalled();
+
+    component.mode = 'mini';
+    component.open = true;
+    fixture.detectChanges();
+
+    event = new KeyboardEvent('keydown', { key: 'Escape' });
+    document.dispatchEvent(event);
+    fixture.detectChanges();
+    expect(component.close).not.toHaveBeenCalled();
+  });
+
+  it('should set proper accessibility attributes on backdrop', () => {
+    component.mode = 'temporary';
+    component.open = true;
+    fixture.detectChanges();
+
+    const backdrop = fixture.nativeElement.querySelector('.bg-black.bg-opacity-50');
+    if (backdrop) {
+      expect(backdrop.getAttribute('aria-hidden')).toBe('true');
+    } else {
+      expect(backdrop).not.toBeNull(); // Fail explicitly
+    }
+  });
+
+  it('should close drawer when close button is clicked in temporary mode', () => {
+    component.mode = 'temporary';
+    component.open = true;
+    fixture.detectChanges();
+
+    jest.spyOn(component, 'close');
+
+    const closeButton = fixture.nativeElement.querySelector('button[aria-label="Close Drawer"]');
+    closeButton.click();
+    fixture.detectChanges();
+
+    expect(component.close).toHaveBeenCalled();
+  });
+
+  it('should apply correct width in mini mode', () => {
+    component.mode = 'mini';
+    component.open = true;
+    fixture.detectChanges();
+
+    const drawer = fixture.nativeElement.querySelector('[role="dialog"]');
+    expect(drawer.classList.contains('w-16')).toBe(true);
+  });
+});

--- a/libs/ngx-tailwind-flex-ui/src/lib/drawer/drawer.component.stories.ts
+++ b/libs/ngx-tailwind-flex-ui/src/lib/drawer/drawer.component.stories.ts
@@ -1,0 +1,68 @@
+import { Meta, StoryFn } from '@storybook/angular';
+import { DrawerComponent } from './drawer.component';
+import { moduleMetadata } from '@storybook/angular';
+import { CommonModule } from '@angular/common';
+
+export default {
+  title: 'Components/Drawer',
+  component: DrawerComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [CommonModule],
+    }),
+  ],
+  argTypes: {
+    position: { control: 'radio', options: ['left', 'right'] },
+    mode: { control: 'radio', options: ['temporary', 'persistent', 'mini'] },
+    open: { control: 'boolean' },
+    openChange: { action: 'openChange' },
+  },
+} as Meta<DrawerComponent>;
+
+const Template: StoryFn<DrawerComponent> = (args) => ({
+  props: {
+    ...args,
+    handleToggle: () => {
+      args.open = !args.open;
+      args.openChange(args.open); // manually emit for Storybook
+    },
+  },
+  template: `
+    <lib-drawer [mode]="mode" [position]="position" [open]="open" (openChange)="openChange($event)">
+      <div drawerContent class="h-full p-4 bg-blue-100">
+        <p class="font-semibold">Drawer content ({{ mode }} | {{ position }})</p>
+      </div>
+      <div mainContent class="p-4">
+        <p>Main content area</p>
+        <button
+          *ngIf="mode === 'temporary'"
+          (click)="handleToggle()"
+          class="mt-4 px-4 py-2 bg-blue-600 text-white rounded"
+        >
+          Toggle Drawer
+        </button>
+      </div>
+    </lib-drawer>
+  `,
+});
+
+export const Default = Template.bind({});
+Default.args = {
+  position: 'left',
+  mode: 'persistent',
+  open: true,
+};
+
+export const Temporary = Template.bind({});
+Temporary.args = {
+  position: 'left',
+  mode: 'temporary',
+  open: false,
+};
+
+export const RightMini = Template.bind({});
+RightMini.args = {
+  position: 'right',
+  mode: 'mini',
+  open: true,
+};

--- a/libs/ngx-tailwind-flex-ui/src/lib/drawer/drawer.component.ts
+++ b/libs/ngx-tailwind-flex-ui/src/lib/drawer/drawer.component.ts
@@ -1,0 +1,99 @@
+import {
+  Component,
+  Input,
+  Output,
+  EventEmitter,
+  HostListener,
+  ChangeDetectionStrategy,
+  HostBinding,
+  ChangeDetectorRef,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'lib-drawer',
+  templateUrl: './drawer.component.html',
+  styleUrls: ['./drawer.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+  imports: [CommonModule],
+})
+export class DrawerComponent {
+  @Input() position: 'left' | 'right' = 'left';
+  @Input()
+  set mode(value: 'persistent' | 'temporary' | 'mini') {
+    this._mode = value;
+    this.cdr.markForCheck(); // Trigger change detection
+  }
+  get mode(): 'persistent' | 'temporary' | 'mini' {
+    return this._mode;
+  }
+  private _mode: 'persistent' | 'temporary' | 'mini' = 'temporary';
+
+  private _open = false;
+
+  @Input()
+  get open(): boolean {
+    return this._open;
+  }
+  set open(value: boolean) {
+    if (this._open !== value) {
+      this._open = value;
+      this.openChange.emit(this._open);
+      this.cdr.markForCheck(); // Trigger change detection
+    }
+  }
+
+  @Output() openChange = new EventEmitter<boolean>();
+
+  constructor(private cdr: ChangeDetectorRef) {}
+
+  get isClosable(): boolean {
+    return this._mode === 'temporary';
+  }
+
+  get backdrop(): boolean {
+    return this._mode === 'temporary' && this._open;
+  }
+
+  @HostListener('document:keydown.escape', ['$event'])
+  onEscape() {
+    if (this.isClosable) {
+      this.close();
+    }
+  }
+
+  toggle(): void {
+    this.open = !this._open;
+  }
+
+  close(): void {
+    this.open = false;
+  }
+
+  openDrawer(): void {
+    this.open = true;
+  }
+
+  @HostBinding('class')
+  get drawerClasses(): string {
+    return [
+      'fixed',
+      'top-0',
+      this.position === 'left' ? 'left-0' : 'right-0',
+      this.getTranslationClass(),
+      this._mode === 'mini' ? 'w-16' : 'w-64',
+      'h-full',
+      'bg-white',
+      'z-40',
+      'transition-transform',
+      'duration-300',
+      'shadow-lg',
+    ].join(' ');
+  }
+
+  private getTranslationClass(): string {
+    if (this._open) return 'translate-x-0';
+    return this.position === 'left' ? '-translate-x-full' : 'translate-x-full';
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "@swc-node/register": "~1.9.1",
         "@swc/core": "~1.5.7",
         "@swc/helpers": "~0.5.11",
+        "@testing-library/jest-dom": "^6.6.3",
         "@types/jest": "^29.5.12",
         "@types/node": "18.16.9",
         "@typescript-eslint/utils": "^8.19.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@swc-node/register": "~1.9.1",
     "@swc/core": "~1.5.7",
     "@swc/helpers": "~0.5.11",
+    "@testing-library/jest-dom": "^6.6.3",
     "@types/jest": "^29.5.12",
     "@types/node": "18.16.9",
     "@typescript-eslint/utils": "^8.19.0",


### PR DESCRIPTION
The DrawerComponent allows developers to add slide-in panels from left to right of the viewport. with support fot various display modes
*Positioning: Configurable left or right drawer.
*Modes:
-temporary: Overlays content, dismissible with a close action.
-persistent: Pushes content to make space for the drawer.
-mini: Compact form, useful for icon-only navigation.

![Screenshot 2025-04-24 110745](https://github.com/user-attachments/assets/5578a7ed-482d-4342-8eee-4dcc95310799)
![Screenshot 2025-04-24 111309](https://github.com/user-attachments/assets/e1feb857-f32a-4f87-96ad-1d639cf81357)
