### PR TITLE
fix(storybook): selectors for accordion

### DIFF
--- a/libs/ngx-tailwind-flex-ui/documentation.json
+++ b/libs/ngx-tailwind-flex-ui/documentation.json
@@ -1942,7 +1942,7 @@
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "Story",
-                "defaultValue": "{\r\n  args: { multi: true },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `\r\n      <app-accordion [multi]=\"multi\">\r\n        <app-accordion-panel header=\"Item A\">\r\n          <p>Content A</p>\r\n        </app-accordion-panel>\r\n        <app-accordion-panel header=\"Item B\">\r\n          <p>Content B</p>\r\n        </app-accordion-panel>\r\n      </app-accordion>\r\n    `,\r\n  }),\r\n}"
+                "defaultValue": "{\r\n  args: { multi: true },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `\r\n      <lib-accordion [multi]=\"multi\">\r\n        <lib-accordion-panel header=\"Item A\">\r\n          <p>Content A</p>\r\n        </lib-accordion-panel>\r\n        <lib-accordion-panel header=\"Item B\">\r\n          <p>Content B</p>\r\n        </lib-accordion-panel>\r\n      </lib-accordion>\r\n    `,\r\n  }),\r\n}"
             },
             {
                 "name": "Outline",
@@ -1992,7 +1992,7 @@
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "Story",
-                "defaultValue": "{\r\n  args: { multi: false },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `\r\n      <app-accordion [multi]=\"multi\">\r\n        <app-accordion-panel header=\"Section 1\">\r\n          <p>Content for section 1</p>\r\n        </app-accordion-panel>\r\n        <app-accordion-panel header=\"Section 2\">\r\n          <p>Content for section 2</p>\r\n        </app-accordion-panel>\r\n      </app-accordion>\r\n    `,\r\n  }),\r\n}"
+                "defaultValue": "{\r\n  args: { multi: false },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `\r\n      <lib-accordion [multi]=\"multi\">\r\n        <lib-accordion-panel header=\"Section 1\">\r\n          <p>Content for section 1</p>\r\n        </lib-accordion-panel>\r\n        <lib-accordion-panel header=\"Section 2\">\r\n          <p>Content for section 2</p>\r\n        </lib-accordion-panel>\r\n      </lib-accordion>\r\n    `,\r\n  }),\r\n}"
             },
             {
                 "name": "SmallBlueIcon",
@@ -2511,7 +2511,7 @@
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "Story",
-                    "defaultValue": "{\r\n  args: { multi: true },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `\r\n      <app-accordion [multi]=\"multi\">\r\n        <app-accordion-panel header=\"Item A\">\r\n          <p>Content A</p>\r\n        </app-accordion-panel>\r\n        <app-accordion-panel header=\"Item B\">\r\n          <p>Content B</p>\r\n        </app-accordion-panel>\r\n      </app-accordion>\r\n    `,\r\n  }),\r\n}"
+                    "defaultValue": "{\r\n  args: { multi: true },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `\r\n      <lib-accordion [multi]=\"multi\">\r\n        <lib-accordion-panel header=\"Item A\">\r\n          <p>Content A</p>\r\n        </lib-accordion-panel>\r\n        <lib-accordion-panel header=\"Item B\">\r\n          <p>Content B</p>\r\n        </lib-accordion-panel>\r\n      </lib-accordion>\r\n    `,\r\n  }),\r\n}"
                 },
                 {
                     "name": "SingleExpansion",
@@ -2521,7 +2521,7 @@
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "Story",
-                    "defaultValue": "{\r\n  args: { multi: false },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `\r\n      <app-accordion [multi]=\"multi\">\r\n        <app-accordion-panel header=\"Section 1\">\r\n          <p>Content for section 1</p>\r\n        </app-accordion-panel>\r\n        <app-accordion-panel header=\"Section 2\">\r\n          <p>Content for section 2</p>\r\n        </app-accordion-panel>\r\n      </app-accordion>\r\n    `,\r\n  }),\r\n}"
+                    "defaultValue": "{\r\n  args: { multi: false },\r\n  render: (args) => ({\r\n    props: args,\r\n    template: `\r\n      <lib-accordion [multi]=\"multi\">\r\n        <lib-accordion-panel header=\"Section 1\">\r\n          <p>Content for section 1</p>\r\n        </lib-accordion-panel>\r\n        <lib-accordion-panel header=\"Section 2\">\r\n          <p>Content for section 2</p>\r\n        </lib-accordion-panel>\r\n      </lib-accordion>\r\n    `,\r\n  }),\r\n}"
                 }
             ]
         },

--- a/libs/ngx-tailwind-flex-ui/src/lib/accordion/accordion.component.stories.ts
+++ b/libs/ngx-tailwind-flex-ui/src/lib/accordion/accordion.component.stories.ts
@@ -28,14 +28,14 @@ export const SingleExpansion: Story = {
   render: (args) => ({
     props: args,
     template: `
-      <app-accordion [multi]="multi">
-        <app-accordion-panel header="Section 1">
+      <lib-accordion [multi]="multi">
+        <lib-accordion-panel header="Section 1">
           <p>Content for section 1</p>
-        </app-accordion-panel>
-        <app-accordion-panel header="Section 2">
+        </lib-accordion-panel>
+        <lib-accordion-panel header="Section 2">
           <p>Content for section 2</p>
-        </app-accordion-panel>
-      </app-accordion>
+        </lib-accordion-panel>
+      </lib-accordion>
     `,
   }),
 };
@@ -45,14 +45,14 @@ export const MultiExpansion: Story = {
   render: (args) => ({
     props: args,
     template: `
-      <app-accordion [multi]="multi">
-        <app-accordion-panel header="Item A">
+      <lib-accordion [multi]="multi">
+        <lib-accordion-panel header="Item A">
           <p>Content A</p>
-        </app-accordion-panel>
-        <app-accordion-panel header="Item B">
+        </lib-accordion-panel>
+        <lib-accordion-panel header="Item B">
           <p>Content B</p>
-        </app-accordion-panel>
-      </app-accordion>
+        </lib-accordion-panel>
+      </lib-accordion>
     `,
   }),
 };


### PR DESCRIPTION
## Summary
- update the Accordion storybook templates to use `lib-accordion` selectors

## Testing
- `npx nx run-many --target=lint` *(fails: needs nx package)*
- `npx nx run-many --target=test` *(fails: needs nx package)*

------
https://chatgpt.com/codex/tasks/task_b_684362b59dac832cb54a759d9a51fed8